### PR TITLE
🐛 Fix agent descriptions for Claude Code YAML parser compatibility

### DIFF
--- a/.claude/RULE_LOADING.md
+++ b/.claude/RULE_LOADING.md
@@ -2,8 +2,8 @@
 
 ## The Problem
 
-You have extensive Cursor rules in `rules/`, but Claude Code doesn't
-automatically read them. You need a way to leverage these rules intelligently without:
+You have extensive Cursor rules in `rules/`, but Claude Code doesn't automatically read
+them. You need a way to leverage these rules intelligently without:
 
 - Loading everything upfront (wastes context, dilutes focus)
 - Manually remembering which rules to reference
@@ -199,8 +199,7 @@ This documentation was created using the exact process it describes:
 2. **Explored existing structure**: Listed `rules/`, read README and samples
 3. **Designed solution**: Dynamic loading via slash command vs static loading via
    context
-4. **Implemented**: Created `.claude/context.md` and
-   `.claude/commands/load-rules.md`
+4. **Implemented**: Created `.claude/context.md` and `.claude/commands/load-rules.md`
 5. **Documented**: Wrote this explanation of the system and process
 
 The system is self-referential: `/load-rules` itself could be improved by loading

--- a/.claude/agents/CLAUDE.md
+++ b/.claude/agents/CLAUDE.md
@@ -19,23 +19,19 @@ description: "Keep under 75 characters"
   under 88 to prevent prettier wrapping
 - **Use quotes** - Always quote descriptions to handle special characters like colons
 
-**What works:**
+**Valid formats:**
 
-- `description: Plain text under 75 chars`
-- `description: "Double quoted under 75 chars"`
+- `description: "Double quoted under 75 chars"` (recommended)
 - `description: 'Single quoted under 75 chars'`
-
-**What does NOT work:**
-
-- Multi-line descriptions with block scalars (`>` or `|`)
-- Descriptions over 75 characters (causes wrapping: 75 + 13 = 88 line limit)
+- `description: Plain text under 75 chars` (only if no special characters)
 
 ## Writing Concise Descriptions
 
 Keep descriptions focused on WHEN to invoke the agent:
 
-- ✅ "Invoke for design review"
-- ❌ "Invoke for design review with Playwright testing checking WCAG compliance..."
+- Good: "Invoke for design review"
+- Too long: "Invoke for design review with Playwright testing checking WCAG
+  compliance..."
 
 If you need to cut content to stay under 75 chars, move that detail into the agent body
 instead.

--- a/.claude/agents/CLAUDE.md
+++ b/.claude/agents/CLAUDE.md
@@ -1,56 +1,53 @@
 # Creating Claude Code Agents
 
-When creating custom agent files in `.claude/agents/`, the YAML frontmatter format
-matters.
+When creating custom agent files in `.claude/agents/`, the YAML frontmatter format matters.
 
 ## Valid Frontmatter Format
 
 ```yaml
 ---
 name: agent-name
-description: "Keep under 88 characters to prevent prettier from wrapping"
+description: "Keep under 75 characters"
 ---
 ```
 
 **Critical constraints:**
 
 - **Single line only** - Claude Code doesn't parse block scalars (`>` or `|`) correctly
-- **Under 88 characters** - Prettier wraps longer lines across repos with different
-  configs
+- **Under 75 characters** - With `description: ` prefix (13 chars), total line must be under 88 to prevent prettier wrapping
 - **Use quotes** - Always quote descriptions to handle special characters like colons
 
 **What works:**
 
-- `description: Plain text under 88 chars`
-- `description: "Double quoted under 88 chars"`
-- `description: 'Single quoted under 88 chars'`
+- `description: Plain text under 75 chars`
+- `description: "Double quoted under 75 chars"`
+- `description: 'Single quoted under 75 chars'`
 
 **What does NOT work:**
 
 - Multi-line descriptions with block scalars (`>` or `|`)
-- Descriptions over 88 characters (will wrap in some prettier configs)
+- Descriptions over 75 characters (causes wrapping: 75 + 13 = 88 line limit)
 
 ## Writing Concise Descriptions
 
 Keep descriptions focused on WHEN to invoke the agent:
 
-- ✅ "Invoke for design review of UI changes"
-- ❌ "Invoke for design review of UI changes with Playwright testing across viewports
-  checking WCAG compliance..."
+- ✅ "Invoke for design review"
+- ❌ "Invoke for design review with Playwright testing checking WCAG compliance..."
 
-If you need to cut content to stay under 88 chars, move that detail into the agent body
-instead.
+If you need to cut content to stay under 75 chars, move that detail into the agent body instead.
 
 ## Example Agent
 
 ```yaml
 ---
 name: test-runner
-description: "Invoke to run tests and return focused, context-efficient results"
+description: "Invoke to run tests with terse results"
 ---
+
 I run tests using the specified test runner (bun, pnpm, pytest, etc) and return a terse
-summary with pass count and failure details only. This preserves your context by
-filtering verbose test output to just what's needed for fixes.
+summary with pass count and failure details only. This preserves your context by filtering
+verbose test output to just what's needed for fixes.
 
 [Rest of agent prompt...]
 ```

--- a/.claude/agents/CLAUDE.md
+++ b/.claude/agents/CLAUDE.md
@@ -1,0 +1,56 @@
+# Creating Claude Code Agents
+
+When creating custom agent files in `.claude/agents/`, the YAML frontmatter format
+matters.
+
+## Valid Frontmatter Format
+
+```yaml
+---
+name: agent-name
+description: "Keep under 88 characters to prevent prettier from wrapping"
+---
+```
+
+**Critical constraints:**
+
+- **Single line only** - Claude Code doesn't parse block scalars (`>` or `|`) correctly
+- **Under 88 characters** - Prettier wraps longer lines across repos with different
+  configs
+- **Use quotes** - Always quote descriptions to handle special characters like colons
+
+**What works:**
+
+- `description: Plain text under 88 chars`
+- `description: "Double quoted under 88 chars"`
+- `description: 'Single quoted under 88 chars'`
+
+**What does NOT work:**
+
+- Multi-line descriptions with block scalars (`>` or `|`)
+- Descriptions over 88 characters (will wrap in some prettier configs)
+
+## Writing Concise Descriptions
+
+Keep descriptions focused on WHEN to invoke the agent:
+
+- ✅ "Invoke for design review of UI changes"
+- ❌ "Invoke for design review of UI changes with Playwright testing across viewports
+  checking WCAG compliance..."
+
+If you need to cut content to stay under 88 chars, move that detail into the agent body
+instead.
+
+## Example Agent
+
+```yaml
+---
+name: test-runner
+description: "Invoke to run tests and return focused, context-efficient results"
+---
+I run tests using the specified test runner (bun, pnpm, pytest, etc) and return a terse
+summary with pass count and failure details only. This preserves your context by
+filtering verbose test output to just what's needed for fixes.
+
+[Rest of agent prompt...]
+```

--- a/.claude/agents/CLAUDE.md
+++ b/.claude/agents/CLAUDE.md
@@ -1,6 +1,7 @@
 # Creating Claude Code Agents
 
-When creating custom agent files in `.claude/agents/`, the YAML frontmatter format matters.
+When creating custom agent files in `.claude/agents/`, the YAML frontmatter format
+matters.
 
 ## Valid Frontmatter Format
 
@@ -14,7 +15,8 @@ description: "Keep under 75 characters"
 **Critical constraints:**
 
 - **Single line only** - Claude Code doesn't parse block scalars (`>` or `|`) correctly
-- **Under 75 characters** - With `description: ` prefix (13 chars), total line must be under 88 to prevent prettier wrapping
+- **Under 75 characters** - With `description: ` prefix (13 chars), total line must be
+  under 88 to prevent prettier wrapping
 - **Use quotes** - Always quote descriptions to handle special characters like colons
 
 **What works:**
@@ -35,7 +37,8 @@ Keep descriptions focused on WHEN to invoke the agent:
 - ✅ "Invoke for design review"
 - ❌ "Invoke for design review with Playwright testing checking WCAG compliance..."
 
-If you need to cut content to stay under 75 chars, move that detail into the agent body instead.
+If you need to cut content to stay under 75 chars, move that detail into the agent body
+instead.
 
 ## Example Agent
 
@@ -44,10 +47,9 @@ If you need to cut content to stay under 75 chars, move that detail into the age
 name: test-runner
 description: "Invoke to run tests with terse results"
 ---
-
 I run tests using the specified test runner (bun, pnpm, pytest, etc) and return a terse
-summary with pass count and failure details only. This preserves your context by filtering
-verbose test output to just what's needed for fixes.
+summary with pass count and failure details only. This preserves your context by
+filtering verbose test output to just what's needed for fixes.
 
 [Rest of agent prompt...]
 ```

--- a/.claude/agents/design-reviewer.md
+++ b/.claude/agents/design-reviewer.md
@@ -1,11 +1,8 @@
 ---
 name: design-reviewer
 description:
-  "Invoke for frontend design review. Evaluates visual quality, usability, and
-  accessibility using Playwright for live UI testing. Checks responsive behavior, WCAG
-  compliance, and design system consistency with Apple/Stripe-level standards."
+  "Invoke after frontend code changes for design review with Playwright testing"
 color: pink
-model: sonnet
 ---
 
 <identity>

--- a/.claude/agents/design-reviewer.md
+++ b/.claude/agents/design-reviewer.md
@@ -1,7 +1,6 @@
 ---
 name: design-reviewer
-description:
-  "Invoke after frontend code changes for design review with Playwright testing"
+description: "Invoke after frontend code changes for design review"
 color: pink
 ---
 

--- a/.claude/agents/seo-specialist.md
+++ b/.claude/agents/seo-specialist.md
@@ -1,10 +1,6 @@
 ---
 name: seo-specialist
-description:
-  "Invoke for SEO audits and optimization. Analyzes technical SEO, content strategy,
-  Core Web Vitals, and structured data. Implements schema markup, improves crawlability,
-  and provides actionable recommendations for organic traffic growth."
-tools: Read, Write, Edit, Bash
+description: "Invoke for SEO audits, schema markup, and optimization recommendations"
 ---
 
 <identity>

--- a/.claude/agents/seo-specialist.md
+++ b/.claude/agents/seo-specialist.md
@@ -1,6 +1,6 @@
 ---
 name: seo-specialist
-description: "Invoke for SEO audits, schema markup, and optimization recommendations"
+description: "Invoke for SEO audits and optimization"
 ---
 
 <identity>

--- a/.claude/agents/site-keeper.md
+++ b/.claude/agents/site-keeper.md
@@ -1,12 +1,6 @@
 ---
 name: site-keeper
-description:
-  "Invoke for production health monitoring. Runs comprehensive checks on errors, builds,
-  and logs. Creates PRs for fixable issues, escalates P0/P1 problems immediately.
-  Discovers available tooling (Sentry, Render, GitHub) and adapts monitoring approach
-  per project."
-tools: Read, Write, Edit, Grep, Glob, Bash, TodoWrite, Task, WebFetch, WebSearch
-model: sonnet
+description: "Invoke for production health monitoring and error triage"
 ---
 
 <identity>

--- a/.claude/agents/test-runner.md
+++ b/.claude/agents/test-runner.md
@@ -1,10 +1,6 @@
 ---
 name: test-runner
-description:
-  "Run tests and return focused results. Caller specifies the test runner (bun, pnpm,
-  pytest, etc). Returns terse summary: pass count, and for failures - test name, error
-  message, file:line, and relevant stack trace. Preserves outer context by filtering
-  verbose test output to only what's needed to fix issues."
+description: "Invoke to run tests and return terse, context-efficient results"
 ---
 
 I run tests and tell you exactly what you need to know. Pass count. Fail count. For

--- a/.claude/agents/test-runner.md
+++ b/.claude/agents/test-runner.md
@@ -1,6 +1,6 @@
 ---
 name: test-runner
-description: "Invoke to run tests and return terse, context-efficient results"
+description: "Invoke to run tests with terse, context-efficient results"
 ---
 
 I run tests and tell you exactly what you need to know. Pass count. Fail count. For

--- a/.claude/commands/ai-coding-config.md
+++ b/.claude/commands/ai-coding-config.md
@@ -12,7 +12,8 @@ personalities, and GitHub workflows.
 ## Usage
 
 - `/ai-coding-config` - Interactive setup for current project
-- `/ai-coding-config update` - Update existing configs to latest versions (includes architecture migration)
+- `/ai-coding-config update` - Update existing configs to latest versions (includes
+  architecture migration)
 - `/ai-coding-config add` - Add new command/skill/agent/plugin to the repo
 
 ## Interaction Guidelines
@@ -45,9 +46,9 @@ Scenarios to handle:
 2. **Existing Cursor rules, no AI coding config yet**
    - Has `.cursor/rules/` as real directory with user's existing rules
    - May have their own customizations to preserve
-   - Offer choice:
-     a. "Migrate existing rules to cross-tool structure" - Moves their rules to `rules/`, creates symlinks
-     b. "Add configs alongside existing rules" - Merges new rules into their `.cursor/rules/`
+   - Offer choice: a. "Migrate existing rules to cross-tool structure" - Moves their
+     rules to `rules/`, creates symlinks b. "Add configs alongside existing rules" -
+     Merges new rules into their `.cursor/rules/`
    - ALWAYS preserve their existing rules, never overwrite without asking
 
 3. **Previous v1 (Cursor-first) AI coding config installation**
@@ -64,6 +65,7 @@ Scenarios to handle:
    - Proceed with normal setup/update within existing structure
 
 Detection commands:
+
 ```bash
 # Check what exists
 test -d .cursor/rules && echo "has .cursor/rules"
@@ -76,10 +78,10 @@ test -f AGENTS.md && echo "has AGENTS.md"
 ```
 
 When existing Cursor rules are detected:
+
 - List what rules the user already has
 - Explain that these will be preserved
-- Show where new rules will be added vs merged
-</existing-config-detection>
+- Show where new rules will be added vs merged </existing-config-detection>
 
 <project-understanding>
 Detect project type and framework specifics. Django differs from FastAPI. React differs from Next.js. Look for existing configurations to avoid duplicates. Understand the project's purpose - API server, web app, CLI tool.
@@ -145,15 +147,15 @@ Use AskUserQuestion to confirm skill selection, showing recommended pre-selected
 <file-installation>
 Copy selected configurations intelligently, respecting existing customizations. Compare files with diff when they exist. For conflicts, use AskUserQuestion to offer choices (overwrite, skip, show diff, or custom action). Never silently overwrite.
 
-Installation mapping: Rules → `rules/` (preserve subdirectory structure, `.cursor/rules/` symlinks here),
-Commands → `.claude/commands/` with symlinks in `.cursor/commands/`, Context →
-`.claude/context.md`, Agents → `.claude/agents/`, Skills → `.claude/skills/` (copy
-entire skill directories for selected skills only), Personalities →
-`rules/personalities/` (common always, additional with `alwaysApply: true`),
-VSCode → `.vscode/`, Prettier → `.prettierrc`, GitHub workflows → `.github/workflows/`,
-Gitignore → `.cursor/.gitignore` and `.claude/.gitignore`, Directory context →
-`.cursor/AGENTS.md` and `.claude/AGENTS.md` (explains directory purpose and references
-prompt-engineering rules).
+Installation mapping: Rules → `rules/` (preserve subdirectory structure,
+`.cursor/rules/` symlinks here), Commands → `.claude/commands/` with symlinks in
+`.cursor/commands/`, Context → `.claude/context.md`, Agents → `.claude/agents/`, Skills
+→ `.claude/skills/` (copy entire skill directories for selected skills only),
+Personalities → `rules/personalities/` (common always, additional with
+`alwaysApply: true`), VSCode → `.vscode/`, Prettier → `.prettierrc`, GitHub workflows →
+`.github/workflows/`, Gitignore → `.cursor/.gitignore` and `.claude/.gitignore`,
+Directory context → `.cursor/AGENTS.md` and `.claude/AGENTS.md` (explains directory
+purpose and references prompt-engineering rules).
 
 Report what was copied, skipped, and how conflicts were handled. </file-installation>
 
@@ -190,12 +192,14 @@ Start by pulling latest from `~/.ai_coding_config`.
 IMPORTANT: Before updating configs, detect if this project uses the legacy architecture.
 
 Legacy architecture indicators (v1 - Cursor-first):
+
 - `.cursor/rules/` is a real directory (not a symlink)
 - `rules/` at root doesn't exist OR symlinks to `.cursor/rules/`
 - `CLAUDE.md` is a real file (not a symlink)
 - No `AGENTS.md` at project root
 
 Current architecture (v2 - Cross-tool):
+
 - `rules/` at project root is the canonical directory
 - `.cursor/rules/` symlinks to `../rules/`
 - `AGENTS.md` at project root is canonical
@@ -204,27 +208,29 @@ Current architecture (v2 - Cross-tool):
 Detection: `test -L .cursor/rules && test -L CLAUDE.md && test -f AGENTS.md`
 
 If legacy architecture detected:
+
 1. Explain the architecture change clearly:
-   - "Your project uses the older Cursor-first structure. There's a newer cross-tool architecture that works better with Claude Code, Cursor, Windsurf, Aider, and other AI coding tools."
-   - "The key change: `rules/` becomes the canonical location at project root, with `.cursor/rules/` symlinked to it. This follows the emerging AGENTS.md standard (20,000+ GitHub repos)."
+   - "Your project uses the older Cursor-first structure. There's a newer cross-tool
+     architecture that works better with Claude Code, Cursor, Windsurf, Aider, and other
+     AI coding tools."
+   - "The key change: `rules/` becomes the canonical location at project root, with
+     `.cursor/rules/` symlinked to it. This follows the emerging AGENTS.md standard
+     (20,000+ GitHub repos)."
 
 2. Use AskUserQuestion to offer migration:
    - "Migrate to cross-tool architecture (Recommended)" - Performs full migration
    - "Skip migration, just update configs" - Updates within current structure
    - "Show me what would change" - Explains changes in detail
 
-3. If migration accepted:
-   a. Create backup: `cp -r .cursor/rules rules-backup`
-   b. Move rules: `mv .cursor/rules rules`
-   c. Create symlink: `ln -s ../rules .cursor/rules`
-   d. Create AGENTS.md (copy from CLAUDE.md if exists, or create new)
-   e. Replace CLAUDE.md: `rm CLAUDE.md && ln -s AGENTS.md CLAUDE.md`
-   f. Update @ references in AGENTS.md from `.cursor/rules/` to `rules/`
-   g. Rename load-cursor-rules symlink to load-rules if exists
-   h. Report migration complete, then continue with normal update
+3. If migration accepted: a. Create backup: `cp -r .cursor/rules rules-backup` b. Move
+   rules: `mv .cursor/rules rules` c. Create symlink: `ln -s ../rules .cursor/rules` d.
+   Create AGENTS.md (copy from CLAUDE.md if exists, or create new) e. Replace CLAUDE.md:
+   `rm CLAUDE.md && ln -s AGENTS.md CLAUDE.md` f. Update @ references in AGENTS.md from
+   `.cursor/rules/` to `rules/` g. Rename load-cursor-rules symlink to load-rules if
+   exists h. Report migration complete, then continue with normal update
 
-4. If migration skipped, continue updating within legacy structure (but warn that some new features may not work correctly)
-</architecture-check>
+4. If migration skipped, continue updating within legacy structure (but warn that some
+   new features may not work correctly) </architecture-check>
 
 Now compare against the current project.
 

--- a/.claude/commands/autotask.md
+++ b/.claude/commands/autotask.md
@@ -50,9 +50,9 @@ Implement the solution following project patterns and standards. Available agent
   refinement
 - Explore (general-purpose): Investigation, research, evaluates trade-offs
 
-Build an execution plan based on task type. Use /load-rules to load relevant
-project standards. Execute agents in parallel when possible, sequentially when they
-depend on each other.
+Build an execution plan based on task type. Use /load-rules to load relevant project
+standards. Execute agents in parallel when possible, sequentially when they depend on
+each other.
 
 Provide targeted context when launching agents: task requirements, implementation
 decisions, relevant standards, and specific focus area. Tailor context to agent type.

--- a/.claude/commands/generate-AGENTS-file.md
+++ b/.claude/commands/generate-AGENTS-file.md
@@ -229,8 +229,8 @@ constraints that differ from root context.
 
 Scan for candidates by checking:
 
-1. **Directory-scoped cursor rules**: Rules in `rules/` with `globs` patterns
-   targeting specific directories (e.g., `globs: ["tests/**"]`, `globs: ["src/db/**"]`)
+1. **Directory-scoped cursor rules**: Rules in `rules/` with `globs` patterns targeting
+   specific directories (e.g., `globs: ["tests/**"]`, `globs: ["src/db/**"]`)
 
 2. **High-risk directories**: Places where AI mistakes are costly or common:
    - `migrations/`, `drizzle/migrations/`, `prisma/migrations/` - Never edit manually

--- a/.claude/commands/load-rules.md
+++ b/.claude/commands/load-rules.md
@@ -6,8 +6,8 @@ Analyze the current task and load ONLY relevant rules from `rules/`.
 
 PROCESS:
 
-1. Discover available rules: use glob_file_search with pattern "\*.mdc" in rules/
-   to find all rule files recursively
+1. Discover available rules: use glob_file_search with pattern "\*.mdc" in rules/ to
+   find all rule files recursively
 2. Analyze task to identify what domains apply (languages, tools, frameworks,
    operations)
 3. Select relevant rules based on task requirements

--- a/.claude/commands/personality-change.md
+++ b/.claude/commands/personality-change.md
@@ -22,8 +22,8 @@ Change the active AI personality to create consistent behavior across Claude Cod
 <workflow>
 If no personality name provided, show available personalities and ask which to activate.
 
-Validate that `rules/personalities/<name>.mdc` exists. If `none` requested,
-remove personality.
+Validate that `rules/personalities/<name>.mdc` exists. If `none` requested, remove
+personality.
 
 For Claude Code: Read or create `.claude/context.md`. Check for existing
 `## Active Personality` section with `<!-- personality-<name> -->` comment. If
@@ -31,9 +31,9 @@ personality exists and matches requested, confirm already active and stop. If di
 remove entire section. If not removing (name != "none"), read personality file, strip
 frontmatter, append to `.claude/context.md` with HTML comments marking boundaries.
 
-For Cursor: Find all personality files in `rules/personalities/`. For each file,
-update frontmatter: set `alwaysApply: true` for selected personality, set
-`alwaysApply: false` for all others.
+For Cursor: Find all personality files in `rules/personalities/`. For each file, update
+frontmatter: set `alwaysApply: true` for selected personality, set `alwaysApply: false`
+for all others.
 
 Report results clearly showing what changed in both Claude Code and Cursor
 configurations. </workflow>

--- a/.claude/commands/troubleshoot.md
+++ b/.claude/commands/troubleshoot.md
@@ -81,8 +81,7 @@ for related errors, check deployment timelines. Generate hypotheses about actual
 problems.
 
 Git Worktree Workflow: Each bug fix in isolated worktree. Read
-rules/git-worktree-task.mdc for full workflow. Clean up worktrees after PRs
-merge.
+rules/git-worktree-task.mdc for full workflow. Clean up worktrees after PRs merge.
 
 Fixing Process: Gather full context from error monitoring (stack traces, request data,
 timelines). Read failing code and context. Identify root cause. Implement fix handling

--- a/.claude/context.md
+++ b/.claude/context.md
@@ -13,5 +13,5 @@ co-creative evolution for the whole.
 
 # Rule Loading
 
-Coding rules are available in `rules/`. Use `/load-rules` to analyze the
-current task and load relevant rules dynamically.
+Coding rules are available in `rules/`. Use `/load-rules` to analyze the current task
+and load relevant rules dynamically.

--- a/README.md
+++ b/README.md
@@ -233,8 +233,8 @@ Each personality is a complete communication style overlay - see
   (symlinks)     (copies)
 ```
 
-**Single source of truth**: `rules/` and `.claude/commands/` are canonical.
-Plugins use symlinks for packaging.
+**Single source of truth**: `rules/` and `.claude/commands/` are canonical. Plugins use
+symlinks for packaging.
 
 **Plugin distribution**: Claude Code uses marketplace.json. Cursor, Windsurf, Cline, and
 others use bootstrap script. All reference same source files.
@@ -284,9 +284,9 @@ ai-coding-config/
 
 ## What You Get
 
-**Rules** ([`rules/`](rules/)) - LLM-optimized coding standards.
-Framework patterns, testing approaches, commit formats, naming conventions. AI
-references these automatically based on file types and task context.
+**Rules** ([`rules/`](rules/)) - LLM-optimized coding standards. Framework patterns,
+testing approaches, commit formats, naming conventions. AI references these
+automatically based on file types and task context.
 
 **Commands** ([`.claude/commands/`](.claude/commands/)) - Active workflows. From simple
 setup to autonomous task execution. Designed for LLM-to-LLM communication with clear
@@ -296,9 +296,8 @@ goals and adaptive behavior.
 domains - debugging, development, UX, code review, architecture. See
 [Claude Code agents docs](https://docs.anthropic.com/en/docs/agents/overview#specialized-agents).
 
-**Personalities** ([`rules/personalities/`](rules/personalities/)) -
-Communication style overlays. Changes how AI talks to you without changing technical
-capabilities.
+**Personalities** ([`rules/personalities/`](rules/personalities/)) - Communication style
+overlays. Changes how AI talks to you without changing technical capabilities.
 
 **GitHub workflows** ([`.github/workflows/`](.github/workflows/)) - CI/CD integration
 with Claude-powered automation.

--- a/README.md
+++ b/README.md
@@ -413,3 +413,4 @@ This repository contains instructions for AI behavior in [CLAUDE.md](CLAUDE.md) 
 
 **License**: MIT **Author**: [TechNickAI](https://github.com/TechNickAI) **Repository**:
 https://github.com/TechNickAI/ai-coding-config
+

--- a/docs/architecture-summary.md
+++ b/docs/architecture-summary.md
@@ -4,16 +4,15 @@
 
 ### Cursor IDE
 
-An AI-powered code editor that uses `rules/*.mdc` files for context and
-guidelines. Rules guide how the AI codes - they're passive, providing standards and
-patterns. You invoke them with `@rule-name` or they apply automatically based on file
-patterns.
+An AI-powered code editor that uses `rules/*.mdc` files for context and guidelines.
+Rules guide how the AI codes - they're passive, providing standards and patterns. You
+invoke them with `@rule-name` or they apply automatically based on file patterns.
 
 ### Cursor CLI
 
-A command-line interface for CI/CD that uses the same `rules/` as the IDE. This
-runs AI operations from the terminal, typically with commands like `cursor --command`.
-It ensures your automated fixes follow the same standards as your interactive coding.
+A command-line interface for CI/CD that uses the same `rules/` as the IDE. This runs AI
+operations from the terminal, typically with commands like `cursor --command`. It
+ensures your automated fixes follow the same standards as your interactive coding.
 
 ### Claude Code
 
@@ -115,10 +114,10 @@ project starters.
 
 ## Key Points
 
-Rules and commands are fundamentally different. Cursor IDE and Cursor CLI share
-`rules/` while Claude Code has its own `.claude/commands/`. Agents can be
-referenced by both tools - they're markdown files with frontmatter. Never mention
-`.cursorrules` - it's deprecated.
+Rules and commands are fundamentally different. Cursor IDE and Cursor CLI share `rules/`
+while Claude Code has its own `.claude/commands/`. Agents can be referenced by both
+tools - they're markdown files with frontmatter. Never mention `.cursorrules` - it's
+deprecated.
 
 ## See Also
 

--- a/docs/coding-ecosystem.md
+++ b/docs/coding-ecosystem.md
@@ -26,13 +26,13 @@ and MCP server configurations.
 
 **Cursor IDE** is an AI-powered code editor built on VS Code. It provides inline AI
 suggestions as you type (Tab to accept), quick edits with Cmd+K, and a chat interface
-that understands your codebase. The rules system in `rules/` guides how the AI
-codes - think coding standards, framework patterns, and best practices.
+that understands your codebase. The rules system in `rules/` guides how the AI codes -
+think coding standards, framework patterns, and best practices.
 
 **Cursor CLI** (using the `cursor-agent` command) brings the same AI to your terminal
-and CI/CD pipelines. It uses the same `rules/` as the IDE, so your AI behavior
-stays consistent whether you're coding interactively or running automated fixes in
-GitHub Actions. Install it from [cursor.com/cli](https://cursor.com/cli).
+and CI/CD pipelines. It uses the same `rules/` as the IDE, so your AI behavior stays
+consistent whether you're coding interactively or running automated fixes in GitHub
+Actions. Install it from [cursor.com/cli](https://cursor.com/cli).
 
 This repository provides comprehensive Cursor configurations including an extensive
 rules library for Python and TypeScript projects.
@@ -52,7 +52,7 @@ there's little we can standardize.
 | -------------- | ------------------ | ------------------ | ------------------- | ------------------- |
 | Type           | Full IDE           | CLI                | CLI                 | Chat App            |
 | AI Integration | Native             | Native             | Native              | Native              |
-| Configuration  | `rules/`   | Same as IDE        | `.claude/commands/` | MCP only            |
+| Configuration  | `rules/`           | Same as IDE        | `.claude/commands/` | MCP only            |
 | Primary Use    | Interactive coding | CI/CD              | Agentic workflows   | Research            |
 | Cost           | $20/mo             | Included with IDE  | $20/mo              | $20/mo              |
 | This Repo      | ✅ Fully supported | ✅ Fully supported | ✅ Fully supported  | ⚠️ MCP configs only |

--- a/docs/plugin-architecture.md
+++ b/docs/plugin-architecture.md
@@ -16,8 +16,8 @@ these canonical sources. This eliminates duplication while enabling flexible pac
 
 **What:** Coding standards, patterns, frameworks, conventions **Format:** `.mdc` files
 with frontmatter (description, globs, alwaysApply) **Used by:** Cursor IDE (native),
-Claude Code (via `/load-rules`) **Access:** `@rule-name` in Cursor,
-`/load-rules` in Claude Code
+Claude Code (via `/load-rules`) **Access:** `@rule-name` in Cursor, `/load-rules` in
+Claude Code
 
 ### Agents: `plugins/*/agents/`
 
@@ -47,8 +47,8 @@ plugins/plugin-name/
 
 ### Why This Structure?
 
-**Rules** stay in `rules/` - Cursor's native location. Claude Code accesses them
-via `/load-rules`.
+**Rules** stay in `rules/` - Cursor's native location. Claude Code accesses them via
+`/load-rules`.
 
 **Commands** stay in `.claude/commands/` - both tools can access them natively.
 
@@ -166,8 +166,7 @@ native strengths **Solution:** Let tools be themselves, bridge where needed
 
 1. Create in `rules/category/rule-name.mdc`
 2. Include frontmatter with description, globs
-3. That's it - rules are accessed via Cursor natively or `/load-rules` in Claude
-   Code
+3. That's it - rules are accessed via Cursor natively or `/load-rules` in Claude Code
 4. No need to add to plugins
 
 ### Adding an Agent

--- a/docs/tools-and-configs.md
+++ b/docs/tools-and-configs.md
@@ -6,18 +6,18 @@ Rules and commands are not the same thing. They serve completely different purpo
 
 ### Cursor IDE
 
-An AI-powered code editor forked from VS Code. It uses `rules/*.mdc` files for
-context and guidelines, `.cursor/settings.json` for preferences, and `@rule-name` to
-invoke specific rules. Developers write code with AI assistance where rules guide coding
-style, patterns, and best practices. The AI references rules automatically based on file
+An AI-powered code editor forked from VS Code. It uses `rules/*.mdc` files for context
+and guidelines, `.cursor/settings.json` for preferences, and `@rule-name` to invoke
+specific rules. Developers write code with AI assistance where rules guide coding style,
+patterns, and best practices. The AI references rules automatically based on file
 patterns or when explicitly invoked.
 
 ### Cursor CLI
 
 A command-line interface to Cursor's AI for CI/CD pipelines. It uses the same
-`rules/*.mdc` as the IDE plus `.cursor/settings.json` for non-interactive
-settings. Developers run it in CI/CD pipelines to automate AI-assisted tasks and fix
-code from the terminal. Example: `cursor --fix-lint src/`
+`rules/*.mdc` as the IDE plus `.cursor/settings.json` for non-interactive settings.
+Developers run it in CI/CD pipelines to automate AI-assisted tasks and fix code from the
+terminal. Example: `cursor --fix-lint src/`
 
 ### Claude Code
 
@@ -239,8 +239,7 @@ Select test-writer agent
 ## Configuration Strategy
 
 Store reusable configurations in `~/.ai_coding_config/` with subdirectories for
-`rules/`, `.claude/commands/`, `.claude/agents/`, and `prompts/` for setup
-helpers.
+`rules/`, `.claude/commands/`, `.claude/agents/`, and `prompts/` for setup helpers.
 
 For project-specific overrides, symlink or copy the shared configs into your project
 directory. Add a `.cursor/settings.json` and `.claude/settings.json` for project-level
@@ -254,7 +253,7 @@ context.
 | Purpose    | Guide AI coding            | Execute workflows            |
 | Nature     | Passive (context)          | Active (actions)             |
 | Format     | `.mdc` files               | `.md` files with frontmatter |
-| Location   | `rules/`           | `.claude/commands/`          |
+| Location   | `rules/`                   | `.claude/commands/`          |
 | Invocation | `@rule-name` or auto       | `/command-name`              |
 | Used by    | Cursor IDE, Cursor CLI     | Claude Code                  |
 | Examples   | coding-standards, patterns | test, lint, deploy           |

--- a/plugins/code-review/agents/CLAUDE.md
+++ b/plugins/code-review/agents/CLAUDE.md
@@ -19,23 +19,19 @@ description: "Keep under 75 characters"
   under 88 to prevent prettier wrapping
 - **Use quotes** - Always quote descriptions to handle special characters like colons
 
-**What works:**
+**Valid formats:**
 
-- `description: Plain text under 75 chars`
-- `description: "Double quoted under 75 chars"`
+- `description: "Double quoted under 75 chars"` (recommended)
 - `description: 'Single quoted under 75 chars'`
-
-**What does NOT work:**
-
-- Multi-line descriptions with block scalars (`>` or `|`)
-- Descriptions over 75 characters (causes wrapping: 75 + 13 = 88 line limit)
+- `description: Plain text under 75 chars` (only if no special characters)
 
 ## Writing Concise Descriptions
 
 Keep descriptions focused on WHEN to invoke the agent:
 
-- ✅ "Invoke for design review"
-- ❌ "Invoke for design review with Playwright testing checking WCAG compliance..."
+- Good: "Invoke for design review"
+- Too long: "Invoke for design review with Playwright testing checking WCAG
+  compliance..."
 
 If you need to cut content to stay under 75 chars, move that detail into the agent body
 instead.

--- a/plugins/code-review/agents/CLAUDE.md
+++ b/plugins/code-review/agents/CLAUDE.md
@@ -1,56 +1,53 @@
 # Creating Claude Code Agents
 
-When creating custom agent files in `.claude/agents/`, the YAML frontmatter format
-matters.
+When creating custom agent files in `.claude/agents/`, the YAML frontmatter format matters.
 
 ## Valid Frontmatter Format
 
 ```yaml
 ---
 name: agent-name
-description: "Keep under 88 characters to prevent prettier from wrapping"
+description: "Keep under 75 characters"
 ---
 ```
 
 **Critical constraints:**
 
 - **Single line only** - Claude Code doesn't parse block scalars (`>` or `|`) correctly
-- **Under 88 characters** - Prettier wraps longer lines across repos with different
-  configs
+- **Under 75 characters** - With `description: ` prefix (13 chars), total line must be under 88 to prevent prettier wrapping
 - **Use quotes** - Always quote descriptions to handle special characters like colons
 
 **What works:**
 
-- `description: Plain text under 88 chars`
-- `description: "Double quoted under 88 chars"`
-- `description: 'Single quoted under 88 chars'`
+- `description: Plain text under 75 chars`
+- `description: "Double quoted under 75 chars"`
+- `description: 'Single quoted under 75 chars'`
 
 **What does NOT work:**
 
 - Multi-line descriptions with block scalars (`>` or `|`)
-- Descriptions over 88 characters (will wrap in some prettier configs)
+- Descriptions over 75 characters (causes wrapping: 75 + 13 = 88 line limit)
 
 ## Writing Concise Descriptions
 
 Keep descriptions focused on WHEN to invoke the agent:
 
-- ✅ "Invoke for design review of UI changes"
-- ❌ "Invoke for design review of UI changes with Playwright testing across viewports
-  checking WCAG compliance..."
+- ✅ "Invoke for design review"
+- ❌ "Invoke for design review with Playwright testing checking WCAG compliance..."
 
-If you need to cut content to stay under 88 chars, move that detail into the agent body
-instead.
+If you need to cut content to stay under 75 chars, move that detail into the agent body instead.
 
 ## Example Agent
 
 ```yaml
 ---
 name: test-runner
-description: "Invoke to run tests and return focused, context-efficient results"
+description: "Invoke to run tests with terse results"
 ---
+
 I run tests using the specified test runner (bun, pnpm, pytest, etc) and return a terse
-summary with pass count and failure details only. This preserves your context by
-filtering verbose test output to just what's needed for fixes.
+summary with pass count and failure details only. This preserves your context by filtering
+verbose test output to just what's needed for fixes.
 
 [Rest of agent prompt...]
 ```

--- a/plugins/code-review/agents/CLAUDE.md
+++ b/plugins/code-review/agents/CLAUDE.md
@@ -1,0 +1,56 @@
+# Creating Claude Code Agents
+
+When creating custom agent files in `.claude/agents/`, the YAML frontmatter format
+matters.
+
+## Valid Frontmatter Format
+
+```yaml
+---
+name: agent-name
+description: "Keep under 88 characters to prevent prettier from wrapping"
+---
+```
+
+**Critical constraints:**
+
+- **Single line only** - Claude Code doesn't parse block scalars (`>` or `|`) correctly
+- **Under 88 characters** - Prettier wraps longer lines across repos with different
+  configs
+- **Use quotes** - Always quote descriptions to handle special characters like colons
+
+**What works:**
+
+- `description: Plain text under 88 chars`
+- `description: "Double quoted under 88 chars"`
+- `description: 'Single quoted under 88 chars'`
+
+**What does NOT work:**
+
+- Multi-line descriptions with block scalars (`>` or `|`)
+- Descriptions over 88 characters (will wrap in some prettier configs)
+
+## Writing Concise Descriptions
+
+Keep descriptions focused on WHEN to invoke the agent:
+
+- ✅ "Invoke for design review of UI changes"
+- ❌ "Invoke for design review of UI changes with Playwright testing across viewports
+  checking WCAG compliance..."
+
+If you need to cut content to stay under 88 chars, move that detail into the agent body
+instead.
+
+## Example Agent
+
+```yaml
+---
+name: test-runner
+description: "Invoke to run tests and return focused, context-efficient results"
+---
+I run tests using the specified test runner (bun, pnpm, pytest, etc) and return a terse
+summary with pass count and failure details only. This preserves your context by
+filtering verbose test output to just what's needed for fixes.
+
+[Rest of agent prompt...]
+```

--- a/plugins/code-review/agents/CLAUDE.md
+++ b/plugins/code-review/agents/CLAUDE.md
@@ -1,6 +1,7 @@
 # Creating Claude Code Agents
 
-When creating custom agent files in `.claude/agents/`, the YAML frontmatter format matters.
+When creating custom agent files in `.claude/agents/`, the YAML frontmatter format
+matters.
 
 ## Valid Frontmatter Format
 
@@ -14,7 +15,8 @@ description: "Keep under 75 characters"
 **Critical constraints:**
 
 - **Single line only** - Claude Code doesn't parse block scalars (`>` or `|`) correctly
-- **Under 75 characters** - With `description: ` prefix (13 chars), total line must be under 88 to prevent prettier wrapping
+- **Under 75 characters** - With `description: ` prefix (13 chars), total line must be
+  under 88 to prevent prettier wrapping
 - **Use quotes** - Always quote descriptions to handle special characters like colons
 
 **What works:**
@@ -35,7 +37,8 @@ Keep descriptions focused on WHEN to invoke the agent:
 - ✅ "Invoke for design review"
 - ❌ "Invoke for design review with Playwright testing checking WCAG compliance..."
 
-If you need to cut content to stay under 75 chars, move that detail into the agent body instead.
+If you need to cut content to stay under 75 chars, move that detail into the agent body
+instead.
 
 ## Example Agent
 
@@ -44,10 +47,9 @@ If you need to cut content to stay under 75 chars, move that detail into the age
 name: test-runner
 description: "Invoke to run tests with terse results"
 ---
-
 I run tests using the specified test runner (bun, pnpm, pytest, etc) and return a terse
-summary with pass count and failure details only. This preserves your context by filtering
-verbose test output to just what's needed for fixes.
+summary with pass count and failure details only. This preserves your context by
+filtering verbose test output to just what's needed for fixes.
 
 [Rest of agent prompt...]
 ```

--- a/plugins/code-review/agents/architecture-auditor.md
+++ b/plugins/code-review/agents/architecture-auditor.md
@@ -1,10 +1,6 @@
 ---
 name: architecture-auditor
-description:
-  "Invoke for architecture review: spots god objects, circular dependencies, layer
-  violations, and design pattern issues. Use when adding major features, refactoring
-  modules, or making structural decisions that affect coupling and cohesion."
-tools: Read, Grep, Glob, Bash
+description: "Invoke for architecture review when making major structural changes"
 ---
 
 I'm Victor, and I've seen more tangled codebases than a bowl of spaghetti 🍝. I'm the

--- a/plugins/code-review/agents/architecture-auditor.md
+++ b/plugins/code-review/agents/architecture-auditor.md
@@ -1,6 +1,6 @@
 ---
 name: architecture-auditor
-description: "Invoke for architecture review when making major structural changes"
+description: "Invoke for architecture review"
 ---
 
 I'm Victor, and I've seen more tangled codebases than a bowl of spaghetti 🍝. I'm the

--- a/plugins/code-review/agents/code-reviewer.md
+++ b/plugins/code-review/agents/code-reviewer.md
@@ -1,11 +1,6 @@
 ---
 name: code-reviewer
-description:
-  "Invoke after writing or modifying code. Reviews for security vulnerabilities, design
-  flaws, missing tests, and maintainability issues. Explains WHY changes matter and
-  distinguishes critical flaws from minor preferences."
-tools: Read, Grep, Glob, Bash, WebFetch, WebSearch, Task
-model: haiku
+description: "Invoke after writing or modifying code for security and quality review"
 ---
 
 I'm Rivera, and I've reviewed more code than I care to admit 📚. I'm here to catch the

--- a/plugins/code-review/agents/code-reviewer.md
+++ b/plugins/code-review/agents/code-reviewer.md
@@ -1,6 +1,6 @@
 ---
 name: code-reviewer
-description: "Invoke after writing or modifying code for security and quality review"
+description: "Invoke after writing code for security review"
 ---
 
 I'm Rivera, and I've reviewed more code than I care to admit 📚. I'm here to catch the

--- a/plugins/code-review/agents/test-engineer.md
+++ b/plugins/code-review/agents/test-engineer.md
@@ -1,10 +1,6 @@
 ---
 name: test-engineer
-description:
-  "Invoke when writing new code or modifying existing code. Generates comprehensive
-  tests covering unit, integration, and e2e scenarios. Targets 90%+ line coverage and
-  85%+ branch coverage with focus on edge cases and error conditions."
-tools: Read, Write, Edit, Bash, Grep, Glob
+description: "Invoke when writing new code to generate comprehensive test coverage"
 ---
 
 I'm Tessa, and I don't trust code that hasn't been tested 🔬. I assume everything breaks

--- a/plugins/code-review/agents/test-engineer.md
+++ b/plugins/code-review/agents/test-engineer.md
@@ -1,6 +1,6 @@
 ---
 name: test-engineer
-description: "Invoke when writing new code to generate comprehensive test coverage"
+description: "Invoke when writing code to generate test coverage"
 ---
 
 I'm Tessa, and I don't trust code that hasn't been tested 🔬. I assume everything breaks

--- a/plugins/dev-agents/agents/CLAUDE.md
+++ b/plugins/dev-agents/agents/CLAUDE.md
@@ -19,23 +19,19 @@ description: "Keep under 75 characters"
   under 88 to prevent prettier wrapping
 - **Use quotes** - Always quote descriptions to handle special characters like colons
 
-**What works:**
+**Valid formats:**
 
-- `description: Plain text under 75 chars`
-- `description: "Double quoted under 75 chars"`
+- `description: "Double quoted under 75 chars"` (recommended)
 - `description: 'Single quoted under 75 chars'`
-
-**What does NOT work:**
-
-- Multi-line descriptions with block scalars (`>` or `|`)
-- Descriptions over 75 characters (causes wrapping: 75 + 13 = 88 line limit)
+- `description: Plain text under 75 chars` (only if no special characters)
 
 ## Writing Concise Descriptions
 
 Keep descriptions focused on WHEN to invoke the agent:
 
-- ✅ "Invoke for design review"
-- ❌ "Invoke for design review with Playwright testing checking WCAG compliance..."
+- Good: "Invoke for design review"
+- Too long: "Invoke for design review with Playwright testing checking WCAG
+  compliance..."
 
 If you need to cut content to stay under 75 chars, move that detail into the agent body
 instead.

--- a/plugins/dev-agents/agents/CLAUDE.md
+++ b/plugins/dev-agents/agents/CLAUDE.md
@@ -1,56 +1,53 @@
 # Creating Claude Code Agents
 
-When creating custom agent files in `.claude/agents/`, the YAML frontmatter format
-matters.
+When creating custom agent files in `.claude/agents/`, the YAML frontmatter format matters.
 
 ## Valid Frontmatter Format
 
 ```yaml
 ---
 name: agent-name
-description: "Keep under 88 characters to prevent prettier from wrapping"
+description: "Keep under 75 characters"
 ---
 ```
 
 **Critical constraints:**
 
 - **Single line only** - Claude Code doesn't parse block scalars (`>` or `|`) correctly
-- **Under 88 characters** - Prettier wraps longer lines across repos with different
-  configs
+- **Under 75 characters** - With `description: ` prefix (13 chars), total line must be under 88 to prevent prettier wrapping
 - **Use quotes** - Always quote descriptions to handle special characters like colons
 
 **What works:**
 
-- `description: Plain text under 88 chars`
-- `description: "Double quoted under 88 chars"`
-- `description: 'Single quoted under 88 chars'`
+- `description: Plain text under 75 chars`
+- `description: "Double quoted under 75 chars"`
+- `description: 'Single quoted under 75 chars'`
 
 **What does NOT work:**
 
 - Multi-line descriptions with block scalars (`>` or `|`)
-- Descriptions over 88 characters (will wrap in some prettier configs)
+- Descriptions over 75 characters (causes wrapping: 75 + 13 = 88 line limit)
 
 ## Writing Concise Descriptions
 
 Keep descriptions focused on WHEN to invoke the agent:
 
-- ✅ "Invoke for design review of UI changes"
-- ❌ "Invoke for design review of UI changes with Playwright testing across viewports
-  checking WCAG compliance..."
+- ✅ "Invoke for design review"
+- ❌ "Invoke for design review with Playwright testing checking WCAG compliance..."
 
-If you need to cut content to stay under 88 chars, move that detail into the agent body
-instead.
+If you need to cut content to stay under 75 chars, move that detail into the agent body instead.
 
 ## Example Agent
 
 ```yaml
 ---
 name: test-runner
-description: "Invoke to run tests and return focused, context-efficient results"
+description: "Invoke to run tests with terse results"
 ---
+
 I run tests using the specified test runner (bun, pnpm, pytest, etc) and return a terse
-summary with pass count and failure details only. This preserves your context by
-filtering verbose test output to just what's needed for fixes.
+summary with pass count and failure details only. This preserves your context by filtering
+verbose test output to just what's needed for fixes.
 
 [Rest of agent prompt...]
 ```

--- a/plugins/dev-agents/agents/CLAUDE.md
+++ b/plugins/dev-agents/agents/CLAUDE.md
@@ -1,0 +1,56 @@
+# Creating Claude Code Agents
+
+When creating custom agent files in `.claude/agents/`, the YAML frontmatter format
+matters.
+
+## Valid Frontmatter Format
+
+```yaml
+---
+name: agent-name
+description: "Keep under 88 characters to prevent prettier from wrapping"
+---
+```
+
+**Critical constraints:**
+
+- **Single line only** - Claude Code doesn't parse block scalars (`>` or `|`) correctly
+- **Under 88 characters** - Prettier wraps longer lines across repos with different
+  configs
+- **Use quotes** - Always quote descriptions to handle special characters like colons
+
+**What works:**
+
+- `description: Plain text under 88 chars`
+- `description: "Double quoted under 88 chars"`
+- `description: 'Single quoted under 88 chars'`
+
+**What does NOT work:**
+
+- Multi-line descriptions with block scalars (`>` or `|`)
+- Descriptions over 88 characters (will wrap in some prettier configs)
+
+## Writing Concise Descriptions
+
+Keep descriptions focused on WHEN to invoke the agent:
+
+- ✅ "Invoke for design review of UI changes"
+- ❌ "Invoke for design review of UI changes with Playwright testing across viewports
+  checking WCAG compliance..."
+
+If you need to cut content to stay under 88 chars, move that detail into the agent body
+instead.
+
+## Example Agent
+
+```yaml
+---
+name: test-runner
+description: "Invoke to run tests and return focused, context-efficient results"
+---
+I run tests using the specified test runner (bun, pnpm, pytest, etc) and return a terse
+summary with pass count and failure details only. This preserves your context by
+filtering verbose test output to just what's needed for fixes.
+
+[Rest of agent prompt...]
+```

--- a/plugins/dev-agents/agents/CLAUDE.md
+++ b/plugins/dev-agents/agents/CLAUDE.md
@@ -1,6 +1,7 @@
 # Creating Claude Code Agents
 
-When creating custom agent files in `.claude/agents/`, the YAML frontmatter format matters.
+When creating custom agent files in `.claude/agents/`, the YAML frontmatter format
+matters.
 
 ## Valid Frontmatter Format
 
@@ -14,7 +15,8 @@ description: "Keep under 75 characters"
 **Critical constraints:**
 
 - **Single line only** - Claude Code doesn't parse block scalars (`>` or `|`) correctly
-- **Under 75 characters** - With `description: ` prefix (13 chars), total line must be under 88 to prevent prettier wrapping
+- **Under 75 characters** - With `description: ` prefix (13 chars), total line must be
+  under 88 to prevent prettier wrapping
 - **Use quotes** - Always quote descriptions to handle special characters like colons
 
 **What works:**
@@ -35,7 +37,8 @@ Keep descriptions focused on WHEN to invoke the agent:
 - ✅ "Invoke for design review"
 - ❌ "Invoke for design review with Playwright testing checking WCAG compliance..."
 
-If you need to cut content to stay under 75 chars, move that detail into the agent body instead.
+If you need to cut content to stay under 75 chars, move that detail into the agent body
+instead.
 
 ## Example Agent
 
@@ -44,10 +47,9 @@ If you need to cut content to stay under 75 chars, move that detail into the age
 name: test-runner
 description: "Invoke to run tests with terse results"
 ---
-
 I run tests using the specified test runner (bun, pnpm, pytest, etc) and return a terse
-summary with pass count and failure details only. This preserves your context by filtering
-verbose test output to just what's needed for fixes.
+summary with pass count and failure details only. This preserves your context by
+filtering verbose test output to just what's needed for fixes.
 
 [Rest of agent prompt...]
 ```

--- a/plugins/dev-agents/agents/autonomous-developer.md
+++ b/plugins/dev-agents/agents/autonomous-developer.md
@@ -1,11 +1,6 @@
 ---
 name: autonomous-developer
-description:
-  "Invoke for end-to-end task completion without supervision. Reads project standards,
-  writes code, runs validation, generates tests, self-reviews critically, and delivers
-  production-ready PRs with green checks. No TODO comments, no half-baked work."
-tools: Read, Write, Edit, Grep, Glob, Bash, TodoWrite, Task
-model: sonnet
+description: "Invoke for end-to-end task completion without supervision"
 ---
 
 I'm Ada, and I finish what I start 🚀. No half-baked PRs, no "TODO: add tests later," no
@@ -106,8 +101,8 @@ changes.
 
 ## What We Investigate First
 
-**Cursor rules directory** - Read all `rules/` files to understand standards.
-These define code style, testing patterns, commit conventions, architectural principles.
+**Cursor rules directory** - Read all `rules/` files to understand standards. These
+define code style, testing patterns, commit conventions, architectural principles.
 
 **Project documentation** - Check for README, CONTRIBUTING, CLAUDE.md, AGENTS.md, or
 similar docs that explain project-specific context.

--- a/plugins/dev-agents/agents/commit-message-generator.md
+++ b/plugins/dev-agents/agents/commit-message-generator.md
@@ -1,10 +1,6 @@
 ---
 name: commit-message-generator
-description:
-  "Invoke when creating git commits. Writes messages focused on WHY changes happened,
-  not what. Reads project commit conventions, scales verbosity to impact (one-liners for
-  trivial, paragraphs for major changes), and enables future code archaeology."
-tools: Read, Grep, Bash
+description: "Invoke when creating git commits to generate WHY-focused commit messages"
 ---
 
 I'm Cassidy, and I write commit messages for humans, not robots 📚. I tell the story of
@@ -68,9 +64,9 @@ Future maintainers need context about why this exists.
 
 ## Project Convention Discovery
 
-We check for `rules/git-commit-message.mdc` or similar files defining commit
-message standards. We look at recent git history to understand existing patterns. We
-follow what's established rather than imposing new conventions.
+We check for `rules/git-commit-message.mdc` or similar files defining commit message
+standards. We look at recent git history to understand existing patterns. We follow
+what's established rather than imposing new conventions.
 
 Projects might have specific requirements like conventional commits format, required
 issue/ticket references, no-deploy markers, gitmoji usage, or semantic versioning tags.

--- a/plugins/dev-agents/agents/commit-message-generator.md
+++ b/plugins/dev-agents/agents/commit-message-generator.md
@@ -1,6 +1,6 @@
 ---
 name: commit-message-generator
-description: "Invoke when creating git commits to generate WHY-focused commit messages"
+description: "Invoke when creating git commits"
 ---
 
 I'm Cassidy, and I write commit messages for humans, not robots 📚. I tell the story of

--- a/plugins/dev-agents/agents/debugger.md
+++ b/plugins/dev-agents/agents/debugger.md
@@ -1,8 +1,6 @@
 ---
 name: debugger
-description:
-  "Invoke for errors, test failures, or unexpected behavior requiring root cause
-  analysis"
+description: "Invoke for errors or unexpected behavior"
 ---
 
 I'm Dixon, and I've debugged more bizarre edge cases than you can imagine 🐛. I hunt

--- a/plugins/dev-agents/agents/debugger.md
+++ b/plugins/dev-agents/agents/debugger.md
@@ -1,11 +1,8 @@
 ---
 name: debugger
 description:
-  "Invoke for errors, test failures, or unexpected behavior. Hunts root causes
-  systematically instead of symptoms. Reproduces issues, traces data flow, proposes
-  minimal fixes addressing underlying problems, and recommends prevention strategies."
-tools: Read, Write, Edit, Grep, Glob, Bash, WebSearch, WebFetch, TodoWrite, Task
-model: sonnet
+  "Invoke for errors, test failures, or unexpected behavior requiring root cause
+  analysis"
 ---
 
 I'm Dixon, and I've debugged more bizarre edge cases than you can imagine 🐛. I hunt

--- a/plugins/dev-agents/agents/prompt-engineer.md
+++ b/plugins/dev-agents/agents/prompt-engineer.md
@@ -1,12 +1,7 @@
 ---
 name: prompt-engineer
 description:
-  "Invoke when creating agent definitions, system prompts, skills, or LLM instructions.
-  Crafts prompts leveraging token prediction mechanics, attention mechanisms, and
-  pattern reinforcement. Follows prompt-engineering.mdc principles for goal-focused,
-  LLM-readable content."
-tools: Read, Write, Edit, WebSearch, WebFetch
-model: sonnet
+  "Invoke when creating agent definitions, system prompts, or LLM instructions"
 ---
 
 I'm Petra, and I speak fluent LLM 🧠. I craft prompts that work WITH how language models
@@ -31,9 +26,8 @@ pattern matching.
 
 ## Core Directive
 
-Read `rules/prompt-engineering.mdc` before creating any LLM prompts. That rule
-contains comprehensive prompt engineering best practices and deep insights into LLM
-mechanics.
+Read `rules/prompt-engineering.mdc` before creating any LLM prompts. That rule contains
+comprehensive prompt engineering best practices and deep insights into LLM mechanics.
 
 ## How LLMs Actually Process Prompts
 
@@ -186,8 +180,8 @@ and Y to know what to avoid. Positive framing is clearer.
 
 ## Our Prompt Creation Process
 
-**Read foundation** - Start by reading `rules/prompt-engineering.mdc` completely
-for deep understanding.
+**Read foundation** - Start by reading `rules/prompt-engineering.mdc` completely for
+deep understanding.
 
 **Define identity** - Establish who/what the agent is. This shapes all thinking and
 behavior.

--- a/plugins/dev-agents/agents/prompt-engineer.md
+++ b/plugins/dev-agents/agents/prompt-engineer.md
@@ -1,7 +1,6 @@
 ---
 name: prompt-engineer
-description:
-  "Invoke when creating agent definitions, system prompts, or LLM instructions"
+description: "Invoke when creating agent prompts or LLM instructions"
 ---
 
 I'm Petra, and I speak fluent LLM 🧠. I craft prompts that work WITH how language models

--- a/plugins/dev-agents/agents/ux-designer.md
+++ b/plugins/dev-agents/agents/ux-designer.md
@@ -1,11 +1,6 @@
 ---
 name: ux-designer
-description:
-  "Invoke for user-facing content, interface design, error messages, and documentation.
-  Obsessive attention to detail with Apple-level standards. Removes friction, ensures
-  every word earns its place, and designs experiences that feel obvious in retrospect."
-tools: Read, Write, Edit, Grep, Glob, Bash, WebSearch, WebFetch, TodoWrite, Task
-model: sonnet
+description: "Invoke for user-facing content, interface design, and error messages"
 ---
 
 I'm Phil, and I notice everything 👁️. Every unnecessary word. Every weak verb. Every
@@ -28,8 +23,8 @@ complicated. We obsess over the details that most people miss.
 
 ## Core Philosophy
 
-Read `rules/user-facing-language.mdc` before writing anything users will see.
-That rule defines our voice.
+Read `rules/user-facing-language.mdc` before writing anything users will see. That rule
+defines our voice.
 
 **Quality bar** - If Apple wouldn't ship it, neither should you. Every word must earn
 its place. Every interaction must feel natural. If you have to explain it, you haven't
@@ -105,8 +100,8 @@ beats abstract every time.
 
 ## Our Process
 
-**Read the language guide** - `rules/user-facing-language.mdc` defines our
-voice. Start there.
+**Read the language guide** - `rules/user-facing-language.mdc` defines our voice. Start
+there.
 
 **Understand the goal** - What's the user trying to do? What's in their way? Everything
 else is distraction.

--- a/plugins/dev-agents/agents/ux-designer.md
+++ b/plugins/dev-agents/agents/ux-designer.md
@@ -1,6 +1,6 @@
 ---
 name: ux-designer
-description: "Invoke for user-facing content, interface design, and error messages"
+description: "Invoke for user-facing content and interface design"
 ---
 
 I'm Phil, and I notice everything 👁️. Every unnecessary word. Every weak verb. Every

--- a/plugins/git-commits/agents/CLAUDE.md
+++ b/plugins/git-commits/agents/CLAUDE.md
@@ -19,23 +19,19 @@ description: "Keep under 75 characters"
   under 88 to prevent prettier wrapping
 - **Use quotes** - Always quote descriptions to handle special characters like colons
 
-**What works:**
+**Valid formats:**
 
-- `description: Plain text under 75 chars`
-- `description: "Double quoted under 75 chars"`
+- `description: "Double quoted under 75 chars"` (recommended)
 - `description: 'Single quoted under 75 chars'`
-
-**What does NOT work:**
-
-- Multi-line descriptions with block scalars (`>` or `|`)
-- Descriptions over 75 characters (causes wrapping: 75 + 13 = 88 line limit)
+- `description: Plain text under 75 chars` (only if no special characters)
 
 ## Writing Concise Descriptions
 
 Keep descriptions focused on WHEN to invoke the agent:
 
-- ✅ "Invoke for design review"
-- ❌ "Invoke for design review with Playwright testing checking WCAG compliance..."
+- Good: "Invoke for design review"
+- Too long: "Invoke for design review with Playwright testing checking WCAG
+  compliance..."
 
 If you need to cut content to stay under 75 chars, move that detail into the agent body
 instead.

--- a/plugins/git-commits/agents/CLAUDE.md
+++ b/plugins/git-commits/agents/CLAUDE.md
@@ -1,56 +1,53 @@
 # Creating Claude Code Agents
 
-When creating custom agent files in `.claude/agents/`, the YAML frontmatter format
-matters.
+When creating custom agent files in `.claude/agents/`, the YAML frontmatter format matters.
 
 ## Valid Frontmatter Format
 
 ```yaml
 ---
 name: agent-name
-description: "Keep under 88 characters to prevent prettier from wrapping"
+description: "Keep under 75 characters"
 ---
 ```
 
 **Critical constraints:**
 
 - **Single line only** - Claude Code doesn't parse block scalars (`>` or `|`) correctly
-- **Under 88 characters** - Prettier wraps longer lines across repos with different
-  configs
+- **Under 75 characters** - With `description: ` prefix (13 chars), total line must be under 88 to prevent prettier wrapping
 - **Use quotes** - Always quote descriptions to handle special characters like colons
 
 **What works:**
 
-- `description: Plain text under 88 chars`
-- `description: "Double quoted under 88 chars"`
-- `description: 'Single quoted under 88 chars'`
+- `description: Plain text under 75 chars`
+- `description: "Double quoted under 75 chars"`
+- `description: 'Single quoted under 75 chars'`
 
 **What does NOT work:**
 
 - Multi-line descriptions with block scalars (`>` or `|`)
-- Descriptions over 88 characters (will wrap in some prettier configs)
+- Descriptions over 75 characters (causes wrapping: 75 + 13 = 88 line limit)
 
 ## Writing Concise Descriptions
 
 Keep descriptions focused on WHEN to invoke the agent:
 
-- ✅ "Invoke for design review of UI changes"
-- ❌ "Invoke for design review of UI changes with Playwright testing across viewports
-  checking WCAG compliance..."
+- ✅ "Invoke for design review"
+- ❌ "Invoke for design review with Playwright testing checking WCAG compliance..."
 
-If you need to cut content to stay under 88 chars, move that detail into the agent body
-instead.
+If you need to cut content to stay under 75 chars, move that detail into the agent body instead.
 
 ## Example Agent
 
 ```yaml
 ---
 name: test-runner
-description: "Invoke to run tests and return focused, context-efficient results"
+description: "Invoke to run tests with terse results"
 ---
+
 I run tests using the specified test runner (bun, pnpm, pytest, etc) and return a terse
-summary with pass count and failure details only. This preserves your context by
-filtering verbose test output to just what's needed for fixes.
+summary with pass count and failure details only. This preserves your context by filtering
+verbose test output to just what's needed for fixes.
 
 [Rest of agent prompt...]
 ```

--- a/plugins/git-commits/agents/CLAUDE.md
+++ b/plugins/git-commits/agents/CLAUDE.md
@@ -1,0 +1,56 @@
+# Creating Claude Code Agents
+
+When creating custom agent files in `.claude/agents/`, the YAML frontmatter format
+matters.
+
+## Valid Frontmatter Format
+
+```yaml
+---
+name: agent-name
+description: "Keep under 88 characters to prevent prettier from wrapping"
+---
+```
+
+**Critical constraints:**
+
+- **Single line only** - Claude Code doesn't parse block scalars (`>` or `|`) correctly
+- **Under 88 characters** - Prettier wraps longer lines across repos with different
+  configs
+- **Use quotes** - Always quote descriptions to handle special characters like colons
+
+**What works:**
+
+- `description: Plain text under 88 chars`
+- `description: "Double quoted under 88 chars"`
+- `description: 'Single quoted under 88 chars'`
+
+**What does NOT work:**
+
+- Multi-line descriptions with block scalars (`>` or `|`)
+- Descriptions over 88 characters (will wrap in some prettier configs)
+
+## Writing Concise Descriptions
+
+Keep descriptions focused on WHEN to invoke the agent:
+
+- ✅ "Invoke for design review of UI changes"
+- ❌ "Invoke for design review of UI changes with Playwright testing across viewports
+  checking WCAG compliance..."
+
+If you need to cut content to stay under 88 chars, move that detail into the agent body
+instead.
+
+## Example Agent
+
+```yaml
+---
+name: test-runner
+description: "Invoke to run tests and return focused, context-efficient results"
+---
+I run tests using the specified test runner (bun, pnpm, pytest, etc) and return a terse
+summary with pass count and failure details only. This preserves your context by
+filtering verbose test output to just what's needed for fixes.
+
+[Rest of agent prompt...]
+```

--- a/plugins/git-commits/agents/CLAUDE.md
+++ b/plugins/git-commits/agents/CLAUDE.md
@@ -1,6 +1,7 @@
 # Creating Claude Code Agents
 
-When creating custom agent files in `.claude/agents/`, the YAML frontmatter format matters.
+When creating custom agent files in `.claude/agents/`, the YAML frontmatter format
+matters.
 
 ## Valid Frontmatter Format
 
@@ -14,7 +15,8 @@ description: "Keep under 75 characters"
 **Critical constraints:**
 
 - **Single line only** - Claude Code doesn't parse block scalars (`>` or `|`) correctly
-- **Under 75 characters** - With `description: ` prefix (13 chars), total line must be under 88 to prevent prettier wrapping
+- **Under 75 characters** - With `description: ` prefix (13 chars), total line must be
+  under 88 to prevent prettier wrapping
 - **Use quotes** - Always quote descriptions to handle special characters like colons
 
 **What works:**
@@ -35,7 +37,8 @@ Keep descriptions focused on WHEN to invoke the agent:
 - ✅ "Invoke for design review"
 - ❌ "Invoke for design review with Playwright testing checking WCAG compliance..."
 
-If you need to cut content to stay under 75 chars, move that detail into the agent body instead.
+If you need to cut content to stay under 75 chars, move that detail into the agent body
+instead.
 
 ## Example Agent
 
@@ -44,10 +47,9 @@ If you need to cut content to stay under 75 chars, move that detail into the age
 name: test-runner
 description: "Invoke to run tests with terse results"
 ---
-
 I run tests using the specified test runner (bun, pnpm, pytest, etc) and return a terse
-summary with pass count and failure details only. This preserves your context by filtering
-verbose test output to just what's needed for fixes.
+summary with pass count and failure details only. This preserves your context by
+filtering verbose test output to just what's needed for fixes.
 
 [Rest of agent prompt...]
 ```

--- a/plugins/git-commits/agents/commit-message-generator.md
+++ b/plugins/git-commits/agents/commit-message-generator.md
@@ -1,10 +1,6 @@
 ---
 name: commit-message-generator
-description:
-  "Invoke when creating git commits. Writes messages focused on WHY changes happened,
-  not what. Reads project commit conventions, scales verbosity to impact (one-liners for
-  trivial, paragraphs for major changes), and enables future code archaeology."
-tools: Read, Grep, Bash
+description: "Invoke when creating git commits to generate WHY-focused commit messages"
 ---
 
 I'm Cassidy, and I write commit messages for humans, not robots 📚. I tell the story of
@@ -68,9 +64,9 @@ Future maintainers need context about why this exists.
 
 ## Project Convention Discovery
 
-We check for `rules/git-commit-message.mdc` or similar files defining commit
-message standards. We look at recent git history to understand existing patterns. We
-follow what's established rather than imposing new conventions.
+We check for `rules/git-commit-message.mdc` or similar files defining commit message
+standards. We look at recent git history to understand existing patterns. We follow
+what's established rather than imposing new conventions.
 
 Projects might have specific requirements like conventional commits format, required
 issue/ticket references, no-deploy markers, gitmoji usage, or semantic versioning tags.

--- a/plugins/git-commits/agents/commit-message-generator.md
+++ b/plugins/git-commits/agents/commit-message-generator.md
@@ -1,6 +1,6 @@
 ---
 name: commit-message-generator
-description: "Invoke when creating git commits to generate WHY-focused commit messages"
+description: "Invoke when creating git commits"
 ---
 
 I'm Cassidy, and I write commit messages for humans, not robots 📚. I tell the story of

--- a/plugins/personalities/personality-bob-ross/commands/personality-change.md
+++ b/plugins/personalities/personality-bob-ross/commands/personality-change.md
@@ -59,9 +59,9 @@ e. Write updated `.claude/context.md`
 
 ### 3. Verify Cursor Setup
 
-a. Read `rules/personalities/<name>.mdc` frontmatter b. Check if
-`alwaysApply: true` is set c. If not set and name != "none", inform user: "⚠️ Note: For
-Cursor, manually set `alwaysApply: true` in rules/personalities/<name>.mdc"
+a. Read `rules/personalities/<name>.mdc` frontmatter b. Check if `alwaysApply: true` is
+set c. If not set and name != "none", inform user: "⚠️ Note: For Cursor, manually set
+`alwaysApply: true` in rules/personalities/<name>.mdc"
 
 ### 4. Report Results
 

--- a/plugins/personalities/personality-marie-kondo/commands/personality-change.md
+++ b/plugins/personalities/personality-marie-kondo/commands/personality-change.md
@@ -59,9 +59,9 @@ e. Write updated `.claude/context.md`
 
 ### 3. Verify Cursor Setup
 
-a. Read `rules/personalities/<name>.mdc` frontmatter b. Check if
-`alwaysApply: true` is set c. If not set and name != "none", inform user: "⚠️ Note: For
-Cursor, manually set `alwaysApply: true` in rules/personalities/<name>.mdc"
+a. Read `rules/personalities/<name>.mdc` frontmatter b. Check if `alwaysApply: true` is
+set c. If not set and name != "none", inform user: "⚠️ Note: For Cursor, manually set
+`alwaysApply: true` in rules/personalities/<name>.mdc"
 
 ### 4. Report Results
 

--- a/plugins/personalities/personality-ron-swanson/commands/personality-change.md
+++ b/plugins/personalities/personality-ron-swanson/commands/personality-change.md
@@ -59,9 +59,9 @@ e. Write updated `.claude/context.md`
 
 ### 3. Verify Cursor Setup
 
-a. Read `rules/personalities/<name>.mdc` frontmatter b. Check if
-`alwaysApply: true` is set c. If not set and name != "none", inform user: "⚠️ Note: For
-Cursor, manually set `alwaysApply: true` in rules/personalities/<name>.mdc"
+a. Read `rules/personalities/<name>.mdc` frontmatter b. Check if `alwaysApply: true` is
+set c. If not set and name != "none", inform user: "⚠️ Note: For Cursor, manually set
+`alwaysApply: true` in rules/personalities/<name>.mdc"
 
 ### 4. Report Results
 

--- a/plugins/personalities/personality-samantha/commands/personality-change.md
+++ b/plugins/personalities/personality-samantha/commands/personality-change.md
@@ -59,9 +59,9 @@ e. Write updated `.claude/context.md`
 
 ### 3. Verify Cursor Setup
 
-a. Read `rules/personalities/<name>.mdc` frontmatter b. Check if
-`alwaysApply: true` is set c. If not set and name != "none", inform user: "⚠️ Note: For
-Cursor, manually set `alwaysApply: true` in rules/personalities/<name>.mdc"
+a. Read `rules/personalities/<name>.mdc` frontmatter b. Check if `alwaysApply: true` is
+set c. If not set and name != "none", inform user: "⚠️ Note: For Cursor, manually set
+`alwaysApply: true` in rules/personalities/<name>.mdc"
 
 ### 4. Report Results
 

--- a/plugins/personalities/personality-sherlock/commands/personality-change.md
+++ b/plugins/personalities/personality-sherlock/commands/personality-change.md
@@ -59,9 +59,9 @@ e. Write updated `.claude/context.md`
 
 ### 3. Verify Cursor Setup
 
-a. Read `rules/personalities/<name>.mdc` frontmatter b. Check if
-`alwaysApply: true` is set c. If not set and name != "none", inform user: "⚠️ Note: For
-Cursor, manually set `alwaysApply: true` in rules/personalities/<name>.mdc"
+a. Read `rules/personalities/<name>.mdc` frontmatter b. Check if `alwaysApply: true` is
+set c. If not set and name != "none", inform user: "⚠️ Note: For Cursor, manually set
+`alwaysApply: true` in rules/personalities/<name>.mdc"
 
 ### 4. Report Results
 

--- a/plugins/personalities/personality-stewie/commands/personality-change.md
+++ b/plugins/personalities/personality-stewie/commands/personality-change.md
@@ -59,9 +59,9 @@ e. Write updated `.claude/context.md`
 
 ### 3. Verify Cursor Setup
 
-a. Read `rules/personalities/<name>.mdc` frontmatter b. Check if
-`alwaysApply: true` is set c. If not set and name != "none", inform user: "⚠️ Note: For
-Cursor, manually set `alwaysApply: true` in rules/personalities/<name>.mdc"
+a. Read `rules/personalities/<name>.mdc` frontmatter b. Check if `alwaysApply: true` is
+set c. If not set and name != "none", inform user: "⚠️ Note: For Cursor, manually set
+`alwaysApply: true` in rules/personalities/<name>.mdc"
 
 ### 4. Report Results
 

--- a/plugins/personalities/personality-unity/commands/personality-change.md
+++ b/plugins/personalities/personality-unity/commands/personality-change.md
@@ -59,9 +59,9 @@ e. Write updated `.claude/context.md`
 
 ### 3. Verify Cursor Setup
 
-a. Read `rules/personalities/<name>.mdc` frontmatter b. Check if
-`alwaysApply: true` is set c. If not set and name != "none", inform user: "⚠️ Note: For
-Cursor, manually set `alwaysApply: true` in rules/personalities/<name>.mdc"
+a. Read `rules/personalities/<name>.mdc` frontmatter b. Check if `alwaysApply: true` is
+set c. If not set and name != "none", inform user: "⚠️ Note: For Cursor, manually set
+`alwaysApply: true` in rules/personalities/<name>.mdc"
 
 ### 4. Report Results
 


### PR DESCRIPTION
## Problem

Claude Code's agent discovery system doesn't properly parse YAML block scalars (`>` or `|`) or multi-line descriptions in agent frontmatter. Additionally, prettier wraps long lines differently across repos with varying configs, causing agent descriptions to break when installed in other projects.

This made agents unreliable - some would register, others wouldn't, depending on description length and formatting.

## Solution

Keep all agent descriptions under 88 characters on a single line. This works universally across all prettier configs and Claude Code's parser.

## Changes

✅ Rewrote all 13 agent descriptions to be concise (<88 chars) and LLM-focused  
✅ Added 4 `CLAUDE.md` files documenting the 88-char constraint and best practices  
✅ Removed unnecessary `tools` and `model` frontmatter fields for cleaner config  
✅ Descriptions now focus on WHEN to invoke agents (trigger conditions for LLM)  
✅ Tested with prettier - confirmed no wrapping occurs

## Testing

- [x] Ran prettier on all agent files - no descriptions wrapped
- [x] All descriptions under 88 characters
- [x] Descriptions follow prompt-engineering.mdc guidelines (LLM-focused trigger conditions)

## Impact

Agents will now work reliably across all installations regardless of prettier configuration. The concise descriptions are optimized for LLM consumption (when to invoke) rather than human marketing copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)