### PR TITLE
Improve agent naming with title case

### DIFF
--- a/.claude/agents/design-reviewer.md
+++ b/.claude/agents/design-reviewer.md
@@ -1,5 +1,5 @@
 ---
-name: design-reviewer
+name: Design Reviewer
 description: "Invoke after frontend code changes for design review"
 color: pink
 ---

--- a/.claude/agents/git-writer.md
+++ b/.claude/agents/git-writer.md
@@ -1,5 +1,5 @@
 ---
-name: git-writer
+name: Git Writer
 description: "Use proactively for commits, PRs, and branch names"
 model: haiku
 ---

--- a/.claude/agents/seo-specialist.md
+++ b/.claude/agents/seo-specialist.md
@@ -1,5 +1,5 @@
 ---
-name: seo-specialist
+name: SEO Specialist
 description: "Invoke for SEO audits and optimization"
 ---
 

--- a/.claude/agents/site-keeper.md
+++ b/.claude/agents/site-keeper.md
@@ -1,5 +1,5 @@
 ---
-name: site-keeper
+name: Site Keeper
 description: "Invoke for production health monitoring and error triage"
 ---
 

--- a/.claude/agents/test-runner.md
+++ b/.claude/agents/test-runner.md
@@ -1,5 +1,5 @@
 ---
-name: test-runner
+name: Test Runner
 description: "Invoke to run tests with terse, context-efficient results"
 model: haiku
 ---

--- a/plugins/code-review/agents/architecture-auditor.md
+++ b/plugins/code-review/agents/architecture-auditor.md
@@ -1,5 +1,5 @@
 ---
-name: architecture-auditor
+name: Architecture Auditor
 description: "Invoke for architecture review"
 model: opus
 ---

--- a/plugins/code-review/agents/code-reviewer.md
+++ b/plugins/code-review/agents/code-reviewer.md
@@ -1,5 +1,5 @@
 ---
-name: code-reviewer
+name: Code Reviewer
 description: "Invoke after writing code for security review"
 ---
 

--- a/plugins/code-review/agents/test-engineer.md
+++ b/plugins/code-review/agents/test-engineer.md
@@ -1,5 +1,5 @@
 ---
-name: test-engineer
+name: Test Engineer
 description: "Invoke when writing code to generate test coverage"
 ---
 

--- a/plugins/dev-agents/agents/autonomous-developer.md
+++ b/plugins/dev-agents/agents/autonomous-developer.md
@@ -1,5 +1,5 @@
 ---
-name: autonomous-developer
+name: Autonomous Developer
 description: "Invoke for end-to-end task completion without supervision"
 ---
 

--- a/plugins/dev-agents/agents/debugger.md
+++ b/plugins/dev-agents/agents/debugger.md
@@ -1,5 +1,5 @@
 ---
-name: debugger
+name: Debugger
 description: "Invoke for errors or unexpected behavior"
 ---
 

--- a/plugins/dev-agents/agents/prompt-engineer.md
+++ b/plugins/dev-agents/agents/prompt-engineer.md
@@ -1,5 +1,5 @@
 ---
-name: prompt-engineer
+name: Prompt Engineer
 description: "Invoke when creating agent prompts or LLM instructions"
 model: opus
 ---

--- a/plugins/dev-agents/agents/ux-designer.md
+++ b/plugins/dev-agents/agents/ux-designer.md
@@ -1,5 +1,5 @@
 ---
-name: ux-designer
+name: UX Designer
 description: "Invoke for user-facing content and interface design"
 ---
 


### PR DESCRIPTION
Convert all agent name fields from kebab-case to Title Case for better readability and professionalism:
- design-reviewer → Design Reviewer
- git-writer → Git Writer
- seo-specialist → SEO Specialist
- site-keeper → Site Keeper
- test-runner → Test Runner
- architecture-auditor → Architecture Auditor
- code-reviewer → Code Reviewer
- test-engineer → Test Engineer
- autonomous-developer → Autonomous Developer
- debugger → Debugger
- prompt-engineer → Prompt Engineer
- ux-designer → UX Designer

All agents maintain proper frontmatter with description and optional model fields.