### PR TITLE
✨ Detect and help clean up duplicate local command/agent/skill files

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "core",
       "source": "./plugins/core",
       "description": "Essential commands and context for AI-assisted development workflows",
-      "version": "2.0.1",
+      "version": "2.1.0",
       "tags": ["commands", "workflows", "essential"]
     },
     {


### PR DESCRIPTION
## Summary

- Detects when users have both Claude Code marketplace plugins AND local copies of the same commands/agents/skills that override marketplace versions
- Educates users about the plugin marketplace benefits and how it prevents version drift
- Offers users a clear choice: remove duplicates and use marketplace (recommended), or keep both
- Only removes exact filename matches, preserves all custom commands/agents/skills users created
- Handles the special case of `ai-coding-config.md` (always preserved even if duplicate)
- Version bumps: core plugin 2.0.1 → 2.1.0, ai-coding-config.md 2.0.1 → 2.1.0

## Changes

The `/ai-coding-config update` command now includes a `<local-duplicate-cleanup>` section that:

- **Detection**: Reads `~/.claude/plugins/installed_plugins.json` to check if marketplace plugins exist, then uses Glob to compare files in marketplace cache paths vs local project directories
- **Classification**: Separates duplicate files from custom user files
- **Education**: Explains what the plugin marketplace is, why local duplicates create confusion, and the benefits of using marketplace versions
- **User control**: Uses `AskUserQuestion` to let users choose between removing duplicates (recommended) or keeping both
- **Safe removal**: Only deletes exact filename matches, preserves custom files and always keeps `.claude/commands/ai-coding-config.md`

This solves a common problem where projects set up before the marketplace existed have outdated local copies that override marketplace versions, causing version drift and preventing auto-updates.

## Testing

Can be tested on the mcp-hubby project, which has the exact situation this addresses: local copies of core commands/agents/skills alongside marketplace plugins.

Steps to verify:
1. Check that mcp-hubby has both marketplace plugins installed and local `.claude/` files
2. Run `/ai-coding-config update` in mcp-hubby
3. Verify detection identifies the correct duplicates and custom files
4. Test both user choice paths: removing duplicates and keeping both
5. Confirm only exact filename matches are removed
6. Verify `ai-coding-config.md` is always preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)