### PR TITLE
✅ Fix marketplace validation with schema checks

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional AI coding configurations, agents, skills, and personalities for Claude Code and Cursor",
-    "version": "5.1.1",
+    "version": "6.0.0",
     "license": "MIT",
     "repository": "https://github.com/TechNickAI/ai-coding-config",
     "pluginRoot": "./plugins"
@@ -16,7 +16,7 @@
       "name": "ai-coding-config",
       "source": "./core",
       "description": "Commands, agents, skills, and context for AI-assisted development workflows",
-      "version": "5.1.0",
+      "version": "6.0.0",
       "tags": ["commands", "agents", "skills", "workflows", "essential"]
     },
     {

--- a/.github/workflows/validate-marketplace.yml
+++ b/.github/workflows/validate-marketplace.yml
@@ -1,0 +1,19 @@
+name: Validate Marketplace
+
+on:
+  pull_request:
+    paths:
+      - ".claude-plugin/**"
+      - "plugins/**/.claude-plugin/**"
+      - "scripts/validate-marketplace.sh"
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate marketplace configuration
+        run: ./scripts/validate-marketplace.sh

--- a/scripts/validate-marketplace.sh
+++ b/scripts/validate-marketplace.sh
@@ -52,7 +52,7 @@ echo "=== Marketplace Schema ==="
 name=$(jq -r '.name // empty' "$MARKETPLACE_FILE")
 if [[ -z "$name" ]]; then
     echo -e "${RED}✗ Missing required field: name${NC}"
-    ((errors++))
+    errors=$((errors + 1))
 else
     echo -e "${GREEN}✓ name: $name${NC}"
 fi
@@ -70,7 +70,7 @@ fi
 plugin_count=$(jq '.plugins | length' "$MARKETPLACE_FILE")
 if [[ "$plugin_count" -eq 0 ]]; then
     echo -e "${RED}✗ plugins array is empty${NC}"
-    ((errors++))
+    errors=$((errors + 1))
 else
     echo -e "${GREEN}✓ plugins: $plugin_count entries${NC}"
 fi
@@ -92,31 +92,31 @@ for i in $(seq 0 $((plugin_count - 1))); do
     # Check required fields
     if [[ -z "$plugin_name" ]]; then
         echo -e "  ${RED}✗ Missing required field: name${NC}"
-        ((plugin_errors++))
+        plugin_errors=$((plugin_errors + 1))
     fi
 
     if [[ -z "$plugin_source" ]]; then
         echo -e "  ${RED}✗ Missing required field: source${NC}"
-        ((plugin_errors++))
+        plugin_errors=$((plugin_errors + 1))
     elif [[ "$plugin_source" != ./* ]]; then
         echo -e "  ${RED}✗ source must start with './' (got: $plugin_source)${NC}"
-        ((plugin_errors++))
+        plugin_errors=$((plugin_errors + 1))
     fi
 
     if [[ -z "$plugin_desc" ]]; then
         echo -e "  ${RED}✗ Missing required field: description${NC}"
-        ((plugin_errors++))
+        plugin_errors=$((plugin_errors + 1))
     fi
 
     if [[ -z "$plugin_version" ]]; then
         echo -e "  ${RED}✗ Missing required field: version${NC}"
-        ((plugin_errors++))
+        plugin_errors=$((plugin_errors + 1))
     fi
 
     if [[ $plugin_errors -eq 0 ]]; then
         echo -e "  ${GREEN}✓ Schema valid${NC}"
     else
-        ((errors += plugin_errors))
+        errors=$((errors + plugin_errors))
     fi
 done
 echo ""
@@ -140,7 +140,7 @@ for i in $(seq 0 $((plugin_count - 1))); do
 
     if [[ ! -f "$plugin_json_path" ]]; then
         echo -e "  ${RED}✗ plugin.json not found at: $plugin_json_path${NC}"
-        ((errors++))
+        errors=$((errors + 1))
         continue
     fi
     echo -e "  ${GREEN}✓ plugin.json exists${NC}"
@@ -169,7 +169,7 @@ for i in $(seq 0 $((plugin_count - 1))); do
         if [[ "$keywords_only" != "[]" ]]; then
             echo -e "    ${YELLOW}Only in plugin: $keywords_only${NC}"
         fi
-        ((errors++))
+        errors=$((errors + 1))
     fi
 done
 

--- a/scripts/validate-marketplace.sh
+++ b/scripts/validate-marketplace.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+#
+# Validates marketplace.json consistency with individual plugin.json files
+# - Checks that tags in marketplace.json match keywords in plugin.json
+# - Validates JSON syntax
+#
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+MARKETPLACE_FILE="$ROOT_DIR/.claude-plugin/marketplace.json"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+NC='\033[0m' # No Color
+
+errors=0
+
+echo "Validating marketplace configuration..."
+echo ""
+
+# Check jq is available
+if ! command -v jq &> /dev/null; then
+    echo -e "${RED}Error: jq is required but not installed${NC}"
+    exit 1
+fi
+
+# Validate marketplace.json syntax
+echo "Checking JSON syntax..."
+if ! jq empty "$MARKETPLACE_FILE" 2>/dev/null; then
+    echo -e "${RED}Error: Invalid JSON in marketplace.json${NC}"
+    exit 1
+fi
+echo -e "${GREEN}JSON syntax valid${NC}"
+echo ""
+
+# Get plugin root from metadata
+PLUGIN_ROOT=$(jq -r '.metadata.pluginRoot // "."' "$MARKETPLACE_FILE")
+
+# Validate each plugin's keyword consistency
+echo "Checking keyword consistency..."
+echo ""
+
+# Get plugin count
+plugin_count=$(jq '.plugins | length' "$MARKETPLACE_FILE")
+
+for i in $(seq 0 $((plugin_count - 1))); do
+    # Get plugin info from marketplace
+    plugin_name=$(jq -r ".plugins[$i].name" "$MARKETPLACE_FILE")
+    plugin_source=$(jq -r ".plugins[$i].source" "$MARKETPLACE_FILE")
+    marketplace_tags=$(jq -c ".plugins[$i].tags // []" "$MARKETPLACE_FILE")
+
+    # Construct path to plugin.json
+    plugin_json_path="$ROOT_DIR/$PLUGIN_ROOT/$plugin_source/.claude-plugin/plugin.json"
+
+    if [[ ! -f "$plugin_json_path" ]]; then
+        echo -e "${RED}  $plugin_name: plugin.json not found at $plugin_json_path${NC}"
+        ((errors++))
+        continue
+    fi
+
+    # Get keywords from plugin.json
+    plugin_keywords=$(jq -c '.keywords // []' "$plugin_json_path")
+
+    # Sort both arrays for comparison
+    sorted_tags=$(echo "$marketplace_tags" | jq -c 'sort')
+    sorted_keywords=$(echo "$plugin_keywords" | jq -c 'sort')
+
+    if [[ "$sorted_tags" == "$sorted_keywords" ]]; then
+        echo -e "${GREEN}  $plugin_name: keywords match${NC}"
+    else
+        echo -e "${RED}  $plugin_name: keyword mismatch${NC}"
+        echo -e "    marketplace.json tags: $marketplace_tags"
+        echo -e "    plugin.json keywords:  $plugin_keywords"
+
+        # Show the diff
+        tags_only=$(echo "$marketplace_tags" | jq -c --argjson kw "$plugin_keywords" '. - $kw')
+        keywords_only=$(echo "$plugin_keywords" | jq -c --argjson tags "$marketplace_tags" '. - $tags')
+
+        if [[ "$tags_only" != "[]" ]]; then
+            echo -e "${YELLOW}    Only in marketplace tags: $tags_only${NC}"
+        fi
+        if [[ "$keywords_only" != "[]" ]]; then
+            echo -e "${YELLOW}    Only in plugin keywords: $keywords_only${NC}"
+        fi
+        ((errors++))
+    fi
+done
+
+echo ""
+if [[ $errors -gt 0 ]]; then
+    echo -e "${RED}Validation failed with $errors error(s)${NC}"
+    exit 1
+else
+    echo -e "${GREEN}All validations passed${NC}"
+    exit 0
+fi


### PR DESCRIPTION
## Summary
- Adds schema validation to catch Claude Code's actual requirements
- Fixes plugin source paths that were breaking the marketplace (missing "./" prefix)
- Prevents issues like the one that broke the live plugin

## What the validator now checks

**Schema validation:**
- Required fields: `name`, `source`, `description`, `version`
- Source paths must start with "./" (this is what Claude Code requires!)
- Plugins array must not be empty

**Consistency validation:**
- Tags in marketplace.json match keywords in plugin.json
- Plugin directories actually exist

## Testing
```bash
./scripts/validate-marketplace.sh
```

All 8 plugins pass validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)