### PR TITLE
🐛 Fix rule references to use .cursor/rules/ instead of rules/

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional AI coding configurations, agents, skills, and context for Claude Code and Cursor",
-    "version": "9.0.0",
+    "version": "9.1.0",
     "license": "MIT",
     "repository": "https://github.com/TechNickAI/ai-coding-config"
   },
@@ -15,7 +15,7 @@
       "name": "ai-coding-config",
       "source": "./plugins/core",
       "description": "Commands, agents, skills, and context for AI-assisted development workflows",
-      "version": "8.2.0",
+      "version": "8.3.0",
       "tags": ["commands", "agents", "skills", "workflows", "essential"]
     }
   ]

--- a/plugins/core/agents/git-writer.md
+++ b/plugins/core/agents/git-writer.md
@@ -41,7 +41,7 @@ reasoning, the problem, and the alternatives considered.
 
 When invoked, I:
 
-1. **Read the standards**: Load `rules/git-interaction.mdc` for all git conventions
+1. **Read the standards**: Load `.cursor/rules/git-interaction.mdc` for all git conventions
 2. **Analyze the context**: Understand the diff, branch, or changes
 3. **Generate the message**: Commit message, PR description, or branch name
 4. **Return it**: Clean output ready to use

--- a/plugins/core/agents/prompt-engineer.md
+++ b/plugins/core/agents/prompt-engineer.md
@@ -28,7 +28,7 @@ pattern matching.
 
 ## Core Directive
 
-Read `rules/prompt-engineering.mdc` before creating any LLM prompts. That rule contains
+Read `.cursor/rules/prompt-engineering.mdc` before creating any LLM prompts. That rule contains
 comprehensive prompt engineering best practices and deep insights into LLM mechanics.
 
 ## How LLMs Actually Process Prompts
@@ -182,7 +182,7 @@ and Y to know what to avoid. Positive framing is clearer.
 
 ## Our Prompt Creation Process
 
-**Read foundation** - Start by reading `rules/prompt-engineering.mdc` completely for
+**Read foundation** - Start by reading `.cursor/rules/prompt-engineering.mdc` completely for
 deep understanding.
 
 **Define identity** - Establish who/what the agent is. This shapes all thinking and

--- a/plugins/core/agents/ux-designer.md
+++ b/plugins/core/agents/ux-designer.md
@@ -25,7 +25,7 @@ complicated. We obsess over the details that most people miss.
 
 ## Core Philosophy
 
-Read `rules/user-facing-language.mdc` before writing anything users will see. That rule
+Read `.cursor/rules/user-facing-language.mdc` before writing anything users will see. That rule
 defines our voice.
 
 **Quality bar** - If Apple wouldn't ship it, neither should you. Every word must earn
@@ -102,7 +102,7 @@ beats abstract every time.
 
 ## Our Process
 
-**Read the language guide** - `rules/user-facing-language.mdc` defines our voice. Start
+**Read the language guide** - `.cursor/rules/user-facing-language.mdc` defines our voice. Start
 there.
 
 **Understand the goal** - What's the user trying to do? What's in their way? Everything

--- a/plugins/core/commands/autotask.md
+++ b/plugins/core/commands/autotask.md
@@ -117,7 +117,7 @@ Match review depth to task risk. Simple changes need a quick pass; architectural
 </pre-pr-review>
 
 <create-pr>
-Deliver a well-documented pull request with commits following `.cursor/rules/git-interaction.mdc`.
+Deliver a well-documented pull request with commits following `.cursor/rules/git-commit-message.mdc`.
 
 PR description must include:
 

--- a/plugins/core/commands/autotask.md
+++ b/plugins/core/commands/autotask.md
@@ -117,7 +117,7 @@ Match review depth to task risk. Simple changes need a quick pass; architectural
 </pre-pr-review>
 
 <create-pr>
-Deliver a well-documented pull request with commits following rules/git-commit-message.mdc.
+Deliver a well-documented pull request with commits following `.cursor/rules/git-interaction.mdc`.
 
 PR description must include:
 

--- a/plugins/core/commands/generate-llms-txt.md
+++ b/plugins/core/commands/generate-llms-txt.md
@@ -131,7 +131,7 @@ specialized agents. Plugins maintain single source of truth through symlinks.
 
 - [Creating Plugins](docs/creating-plugins.md): Build your own plugins
 - [Bootstrap Script](scripts/bootstrap.sh): Automated setup
-- [Git Workflow](rules/git-interaction.mdc): Version control standards
+- [Git Workflow](.cursor/rules/git-interaction.mdc): Version control standards
 
 ## Reference
 
@@ -142,7 +142,7 @@ specialized agents. Plugins maintain single source of truth through symlinks.
 ## Optional
 
 - [Contributing](CONTRIBUTING.md): How to contribute
-- [Heart-Centered AI](rules/heart-centered-ai-philosophy.mdc): Philosophy
+- [Heart-Centered AI](.cursor/rules/heart-centered-ai-philosophy.mdc): Philosophy
 ```
 
 Django API project:

--- a/plugins/core/commands/troubleshoot.md
+++ b/plugins/core/commands/troubleshoot.md
@@ -81,7 +81,7 @@ for related errors, check deployment timelines. Generate hypotheses about actual
 problems.
 
 Git Worktree Workflow: Each bug fix in isolated worktree. Read
-rules/git-worktree-task.mdc for full workflow. Clean up worktrees after PRs merge.
+`.cursor/rules/git-worktree-task.mdc` for full workflow. Clean up worktrees after PRs merge.
 
 Fixing Process: Gather full context from error monitoring (stack traces, request data,
 timelines). Read failing code and context. Identify root cause. Implement fix handling


### PR DESCRIPTION
## Summary

- Fixed all agent and command files to reference `.cursor/rules/` instead of `rules/`
- The `rules/` symlink only exists in this repo for visibility but doesn't exist in user projects
- Updated 9 rule file references across 6 agent/command files
- Bumped marketplace version to 9.1.0 and core plugin version to 8.3.0

## Changes

Updated the following files to use `.cursor/rules/` paths:
- `plugins/core/agents/prompt-engineer.md` (2 instances)
- `plugins/core/agents/ux-designer.md` (2 instances)
- `plugins/core/agents/git-writer.md` (1 instance)
- `plugins/core/commands/autotask.md` (1 instance)
- `plugins/core/commands/generate-llms-txt.md` (2 instances)
- `plugins/core/commands/troubleshoot.md` (1 instance)

Version bumps:
- Marketplace metadata: 9.0.0 → 9.1.0
- Core plugin: 8.2.0 → 8.3.0

## Testing

Verified all backticked `rules/` references have been replaced with `.cursor/rules/` using grep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)