### PR TITLE
✨ Enhance skills with triggers, add session persistence

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -15,7 +15,7 @@
       "name": "ai-coding-config",
       "source": "./plugins/core",
       "description": "Commands, agents, skills, and context for AI-assisted development workflows",
-      "version": "8.3.0",
+      "version": "8.4.0",
       "tags": ["commands", "agents", "skills", "workflows", "essential"]
     }
   ]

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ build/
 *.temp
 
 .created-prompts/
+
+# Claude Code session data (user-specific, may contain sensitive context)
+.claude/sessions/

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ expertise (debugging, code review).
 
 | Type                                    | Count | Purpose                 |
 | --------------------------------------- | ----- | ----------------------- |
-| [Commands](plugins/core/commands/)      | 15    | Automate workflows      |
+| [Commands](plugins/core/commands/)      | 16    | Automate workflows      |
 | [Agents](plugins/core/agents/)          | 22    | Specialized assistants  |
 | [Rules](rules/)                         | 33    | Coding standards        |
 | [Skills](plugins/core/skills/)          | 5     | Autonomous capabilities |
@@ -110,6 +110,15 @@ parallel worktrees, submits PRs with root cause analysis.
 
 **`/load-rules`** - Loads relevant coding standards for your current task. Working on
 React? Loads React patterns. Writing tests? Testing standards.
+
+**`/session save|resume|list`** - Session persistence across conversations. Save your
+context, decisions, and progress. Resume exactly where you left off - even in a new
+conversation.
+
+```bash
+/session save "auth-refactor"    # Save current session
+/session resume                   # Resume where you left off
+```
 
 ### Highlighted Agents
 

--- a/README.md
+++ b/README.md
@@ -258,5 +258,12 @@ See [contributing guide](docs/contributing.md).
 
 ---
 
+## Discovery
+
+This marketplace is indexed at [claudemarketplaces.com](https://claudemarketplaces.com) -
+the searchable directory of Claude Code plugins.
+
+---
+
 **License**: MIT | **Author**: [TechNickAI](https://github.com/TechNickAI) |
 **Repository**: https://github.com/TechNickAI/ai-coding-config

--- a/plugins/core/.claude-plugin/plugin.json
+++ b/plugins/core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-coding-config",
-  "version": "8.3.0",
+  "version": "8.4.0",
   "description": "Commands, agents, skills, and context for AI-assisted development workflows",
   "author": {
     "name": "TechNickAI",

--- a/plugins/core/.claude-plugin/plugin.json
+++ b/plugins/core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-coding-config",
-  "version": "7.0.0",
+  "version": "8.3.0",
   "description": "Commands, agents, skills, and context for AI-assisted development workflows",
   "author": {
     "name": "TechNickAI",

--- a/plugins/core/commands/session.md
+++ b/plugins/core/commands/session.md
@@ -1,0 +1,161 @@
+---
+description: "Save and resume development sessions across conversations"
+argument-hint: "save|resume|list [name]"
+version: 1.0.0
+---
+
+<objective>
+Maintain continuity across Claude Code sessions. Save your current context, decisions,
+and progress so you can resume exactly where you left off - even in a new conversation.
+</objective>
+
+<session-structure>
+Sessions are stored in `.claude/sessions/` with this structure:
+
+```
+.claude/sessions/
+├── active.json           # Current session pointer
+└── <session-id>/
+    ├── metadata.json     # Session info (name, created, branch, task)
+    ├── context.md        # Decisions, architecture, key context
+    ├── progress.json     # Completed steps, current step, blockers
+    └── files.json        # Key files being worked on
+```
+</session-structure>
+
+<commands>
+## /session save [name]
+
+Save current session state for later resumption.
+
+1. Create session directory with timestamp ID
+2. Capture metadata:
+   - Session name (from argument or auto-generate from task)
+   - Current git branch
+   - Timestamp
+   - Brief task description
+
+3. Write context.md with:
+   - What we're building and why
+   - Key architectural decisions made
+   - Important constraints or requirements
+   - Current approach and alternatives considered
+
+4. Write progress.json with:
+   - Completed steps
+   - Current step in progress
+   - Known blockers or open questions
+   - Next steps planned
+
+5. Write files.json with:
+   - Key files being modified
+   - Files to review on resume
+
+6. Update active.json to point to this session
+
+Example:
+```bash
+/session save "auth-refactor"
+```
+
+## /session resume [name|id]
+
+Resume a saved session.
+
+1. Load session from `.claude/sessions/<id>/`
+2. Read and present context.md summary
+3. Show progress status
+4. List key files for quick orientation
+5. Ask if ready to continue from last step
+
+If no name/id provided, resume the active session (from active.json).
+
+Example:
+```bash
+/session resume auth-refactor
+/session resume      # Resume active session
+```
+
+## /session list
+
+Show all saved sessions with:
+- Session name and ID
+- Creation date
+- Branch
+- Brief task description
+- Progress status (X of Y steps)
+
+Sort by most recently modified.
+</commands>
+
+<context-capture>
+When saving context, capture decisions that matter for resumption:
+
+Good context entries:
+- "Using event-driven architecture for loose coupling between services"
+- "Chose PostgreSQL over MongoDB for ACID compliance requirements"
+- "Auth flow: JWT with refresh tokens, 15min access / 7day refresh"
+
+Skip transient details:
+- Specific error messages (they'll be different on resume)
+- File contents (read them fresh)
+- Conversation history (that's what context.md replaces)
+</context-capture>
+
+<progress-tracking>
+Progress entries should be actionable:
+
+```json
+{
+  "completed": [
+    "Set up database schema",
+    "Implement user model",
+    "Add authentication middleware"
+  ],
+  "current": "Writing login endpoint tests",
+  "blockers": [
+    "Need to decide on rate limiting strategy"
+  ],
+  "next": [
+    "Implement password reset flow",
+    "Add email verification"
+  ]
+}
+```
+</progress-tracking>
+
+<auto-save>
+Consider auto-saving sessions:
+- Before long-running operations
+- When switching branches
+- At natural breakpoints (commit, PR creation)
+- When context window gets full (before compaction)
+
+Ask before auto-saving: "Save session before [action]? (y/n)"
+</auto-save>
+
+<resumption-flow>
+When resuming a session:
+
+1. **Orient**: "Resuming session 'auth-refactor' from 2 hours ago"
+2. **Context**: Brief summary of what we were doing and key decisions
+3. **Progress**: "Completed 3 of 7 steps. Currently on: Writing login tests"
+4. **Blockers**: Any open questions or blockers noted
+5. **Ready check**: "Ready to continue with [current step]?"
+
+This gets the user (and Claude) back up to speed quickly without re-explaining everything.
+</resumption-flow>
+
+<best-practices>
+Save sessions when:
+- Ending a work session (lunch, EOD, context switch)
+- Before risky operations
+- At major milestones
+- When you'd want to remember "where was I?"
+
+Resume sessions when:
+- Starting a new Claude Code conversation
+- Returning to a task after a break
+- Handing off to another developer
+- Context got compacted and you lost state
+</best-practices>

--- a/plugins/core/commands/session.md
+++ b/plugins/core/commands/session.md
@@ -146,6 +146,14 @@ When resuming a session:
 This gets the user (and Claude) back up to speed quickly without re-explaining everything.
 </resumption-flow>
 
+<privacy-notice>
+Session files may contain sensitive information including architectural decisions, code
+context, and file paths. The `.claude/sessions/` directory is gitignored by default.
+
+Never commit session data to version control. Review session contents before sharing
+with team members.
+</privacy-notice>
+
 <best-practices>
 Save sessions when:
 - Ending a work session (lunch, EOD, context switch)

--- a/plugins/core/skills/CLAUDE.md
+++ b/plugins/core/skills/CLAUDE.md
@@ -8,33 +8,42 @@ matters.
 ```yaml
 ---
 name: skill-name
-description: "Keep under 75 characters"
+description: "Keep under 75 characters - trigger-only!"
+version: 1.0.0
+category: debugging
+triggers:
+  - "natural language phrase"
+  - "another trigger"
 ---
 ```
 
-**Critical constraints:**
+## Field Requirements
 
-- **Single line only** - Claude Code doesn't parse block scalars (`>` or `|`) correctly
-- **Under 75 characters** - With `description: ` prefix (13 chars), total line must be
-  under 88 to prevent prettier wrapping
-- **Use quotes** - Always quote descriptions to handle special characters like colons
+**name**: Letters, numbers, hyphens only. Use kebab-case (e.g., `systematic-debugging`).
 
-**Valid formats:**
+**description**: Trigger-only! Start with "Use when..." and describe ONLY triggering
+conditions. No process details. Under 75 characters.
 
-- `description: "Double quoted under 75 chars"` (recommended)
-- `description: 'Single quoted under 75 chars'`
-- `description: Plain text under 75 chars` (only if no special characters)
+- Good: `"Use when rough ideas need design before code"`
+- Bad: `"Use when ideas need design - explores options and validates incrementally"`
 
-## Writing Concise Descriptions
+The "Description Trap": If your description contains process details, Claude follows the
+short description instead of reading the full skill content.
 
-Keep descriptions focused on WHEN to use the skill:
+**version**: Semantic versioning. Bump when updating the skill.
 
-- Good: "Use when rough ideas need design before code"
-- Too long: "Use when developing rough ideas into designs before writing code. Refines
-  concepts through collaborative questioning..."
+**category**: Grouping for discovery. Common categories:
+- `planning` - Design, architecture, brainstorming
+- `debugging` - Error investigation, root cause analysis
+- `research` - Web lookups, documentation review
+- `testing` - Test writing, coverage analysis
+- `meta` - Skills about skills, configuration
 
-If you need to cut content to stay under 75 chars, move that detail into the skill body
-instead.
+**triggers**: Natural language phrases that activate this skill. Include:
+- Keywords users naturally say ("debug", "brainstorm", "research")
+- Questions ("why is this", "is this still")
+- Symptoms ("not working", "test failing")
+- Tool names ("youtube", "SKILL.md")
 
 ## Example Skill
 
@@ -42,14 +51,30 @@ instead.
 ---
 name: systematic-debugging
 description: "Use for bugs, test failures, or unexpected behavior needing root cause"
+version: 1.1.0
+category: debugging
+triggers:
+  - "debug"
+  - "investigate"
+  - "root cause"
+  - "why is this"
+  - "not working"
+  - "test failing"
 ---
 
 <objective>
 Find the root cause before writing fixes. Understanding why something breaks leads to
-correct fixes. Guessing wastes time and creates new problems.
+correct fixes.
 
 Core principle: If you can't explain WHY it's broken, you're not ready to fix it.
 </objective>
 
 [Rest of skill content...]
 ```
+
+## Critical Constraints
+
+- **Single line descriptions** - Claude Code doesn't parse block scalars (`>` or `|`)
+- **Under 75 characters** - With `description: ` prefix, total line must be under 88
+- **Use quotes** - Always quote descriptions to handle special characters
+- **Trigger-only descriptions** - No process details in the description field

--- a/plugins/core/skills/brainstorming/SKILL.md
+++ b/plugins/core/skills/brainstorming/SKILL.md
@@ -1,7 +1,15 @@
 ---
 name: brainstorming
 description: "Use when rough ideas need design before code or multiple approaches"
-version: 0.2.0
+version: 0.3.0
+category: planning
+triggers:
+  - "brainstorm"
+  - "design session"
+  - "multiple approaches"
+  - "explore options"
+  - "unclear implementation"
+  - "fuzzy requirements"
 ---
 
 <objective>

--- a/plugins/core/skills/research/SKILL.md
+++ b/plugins/core/skills/research/SKILL.md
@@ -1,7 +1,16 @@
 ---
 name: research
 description: "Use when current web info needed to avoid broken implementations"
-version: 1.0.0
+version: 1.1.0
+category: research
+triggers:
+  - "research"
+  - "look up"
+  - "check current"
+  - "verify API"
+  - "is this still"
+  - "latest version"
+  - "deprecated"
 ---
 
 <philosophy>

--- a/plugins/core/skills/skill-creator/SKILL.md
+++ b/plugins/core/skills/skill-creator/SKILL.md
@@ -1,7 +1,14 @@
 ---
 name: skill-creator
 description: "Use when creating or editing skills for ai-coding-config repo"
-version: 1.2.0
+version: 1.3.0
+category: meta
+triggers:
+  - "create skill"
+  - "new skill"
+  - "write skill"
+  - "edit skill"
+  - "SKILL.md"
 ---
 
 <objective>

--- a/plugins/core/skills/systematic-debugging/SKILL.md
+++ b/plugins/core/skills/systematic-debugging/SKILL.md
@@ -1,7 +1,17 @@
 ---
 name: systematic-debugging
 description: "Use for bugs, test failures, or unexpected behavior needing root cause"
-version: 1.0.0
+version: 1.1.0
+category: debugging
+triggers:
+  - "debug"
+  - "investigate"
+  - "root cause"
+  - "why is this"
+  - "not working"
+  - "test failing"
+  - "unexpected behavior"
+  - "error"
 ---
 
 <objective>

--- a/plugins/core/skills/youtube-transcript-analyzer/SKILL.md
+++ b/plugins/core/skills/youtube-transcript-analyzer/SKILL.md
@@ -1,7 +1,15 @@
 ---
 name: youtube-transcript-analyzer
 description: "Use when analyzing YouTube videos for research or learning"
-version: 0.4.0
+version: 0.5.0
+category: research
+triggers:
+  - "youtube"
+  - "video transcript"
+  - "analyze video"
+  - "watch this"
+  - "youtube.com"
+  - "youtu.be"
 ---
 
 <objective>


### PR DESCRIPTION
## Summary

- **Skill frontmatter upgrade**: Added `triggers` and `category` fields to all 5 skills for natural language activation
- **Session persistence**: New `/session` command to save/resume development context across conversations
- **Version sync**: Fixed version mismatch between marketplace.json (8.3.0) and plugin.json (was 7.0.0)
- **Discovery**: Added claudemarketplaces.com reference (auto-discovers our marketplace)

## What's New

### Natural Language Skill Activation
Skills now include `triggers` - phrases that activate the skill automatically based on conversation context:

```yaml
triggers:
  - "debug"
  - "investigate"
  - "root cause"
  - "why is this"
  - "not working"
```

This means users don't need to explicitly run `/skill` - skills activate when context matches.

### Session Persistence (`/session`)
Solves the biggest pain point in AI coding: losing context between conversations.

- `/session save [name]` - Capture decisions, progress, key context
- `/session resume [name]` - Pick up exactly where you left off
- `/session list` - View all saved sessions

Sessions store:
- Architectural decisions and context
- Progress tracking (completed, current, next steps)
- Key files being worked on
- Blockers and open questions

### Skill Categories
Skills are now categorized for discovery:
- `planning` - brainstorming
- `debugging` - systematic-debugging
- `research` - research, youtube-transcript-analyzer
- `meta` - skill-creator

## Test plan

- [ ] Verify skills have valid frontmatter with `triggers` and `category`
- [ ] Test `/session save` creates proper directory structure
- [ ] Test `/session resume` loads context correctly
- [ ] Confirm version numbers are synced (8.4.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)