### PR TITLE
♻️ Reframe PR comment triage from priority-based to correctness-based

### DIFF
--- a/.cursor/rules/code-review-standards.mdc
+++ b/.cursor/rules/code-review-standards.mdc
@@ -65,5 +65,5 @@ the documentation would merely restate what the code already says clearly.
 
 Accessibility (ARIA labels, keyboard navigation, screen reader support) is a product
 priority decision that varies by project. Check project or user configuration for the
-team's stance. If no stance is declared, flag for user decision rather than assuming
-either way.
+team's stance. If no stance is declared, present the suggestion to the user with context
+about the scope and ask whether to address or decline.

--- a/.cursor/rules/code-review-standards.mdc
+++ b/.cursor/rules/code-review-standards.mdc
@@ -1,62 +1,69 @@
 ---
 description: When doing code reviews
 alwaysApply: false
-version: 1.0.0
+version: 1.1.0
 ---
 
 # Code Review Standards
 
-This rule defines what feedback is actionable based on project priorities. Use this to
-focus reviews on issues that actually get addressed.
+This rule defines when bot feedback is incorrect given context bots lack. Use this to
+identify suggestions that don't apply, not to skip valid feedback based on priority.
 
 ## Core Philosophy
 
-We ship pragmatically. Fix critical bugs, ensure security, validate core behavior.
-Ignore theoretical edge cases, minor polish, and over-engineering. Trust runtime
-validation over compile-time perfection.
+Address all suggestions where the bot's analysis is correct given full context. Decline
+when you can articulate why the bot's reasoning doesn't hold - valid declines explain
+why the analysis is incorrect, not why addressing it is inconvenient.
 
-## Skip These Issues
+## When Bot Suggestions Don't Apply
 
-Do not include them in reviews.
+These patterns describe situations where bot analysis is typically incorrect. Decline
+with explanation when you can demonstrate the bot's reasoning doesn't hold.
 
-### Transactions for Rare Race Conditions
+### Single-Use Values
 
-Only flag race conditions you can demonstrate happen in practice. Theoretical edge cases
-requiring contrived timing are accepted as-is. Added complexity for extremely rare
-scenarios is not justified.
+Bots flag inline values as "magic strings" needing extraction. This suggestion is wrong
+when the value appears exactly once and context makes the meaning clear. Extracting
+`METHOD_INITIALIZE = "initialize"` for a single use adds indirection without DRY
+benefit. Constants exist to stay DRY across multiple uses, not to avoid inline values.
 
-### Magic Numbers and String Constants
+### Theoretical Race Conditions
 
-Constants exist to stay DRY, not to avoid "magic strings." This isn't Java. If a value
-appears once and the meaning is clear from context, inline is better than indirection.
-Only flag repeated values that would require multiple updates to change. Extracting
-`METHOD_INITIALIZE = "initialize"` for a single use is cargo cult programming.
+Bots flag potential race conditions based on static analysis. This suggestion is wrong
+when operations are already serialized by a queue, mutex, or transaction the bot can't
+see. Add synchronization when profiling or testing reveals actual race conditions.
+
+### Redundant Type Safety
+
+Bots suggest stricter types or null checks. This suggestion is wrong when runtime
+validation already handles the case correctly, or when the type system guarantees the
+condition can't occur. TypeScript serves the code - working code with runtime safety
+takes priority over compile-time type perfection.
+
+### Premature Optimization
+
+Bots flag performance concerns without data. This suggestion is wrong when no profiling
+shows actual performance problems. Optimize based on measurements - complexity should
+yield measurable performance gains.
+
+## Items Requiring Case-by-Case Judgment
+
+These require evaluation in context - sometimes the bot is right, sometimes wrong.
+
+### Test Coverage Gaps
+
+Bot requests for edge case tests: Address if the edge case could reasonably occur and
+cause user-facing issues. Decline if you can demonstrate the scenario is already handled
+by other validation or genuinely can't occur given system constraints.
+
+### Documentation Requests
+
+Bot requests for additional docs: Address if the code is genuinely unclear. Decline if
+the documentation would merely restate what the code already says clearly.
 
 ### Accessibility Improvements
 
-ARIA labels, keyboard navigation, and screen reader support are not current project
-priorities.
-
-### Minor Type Safety Improvements
-
-When runtime checks handle edge cases correctly, compile-time type refinement is
-optional. TypeScript serves the code, not vice versa. Working code takes priority over
-perfect types.
-
-### Test Edge Cases
-
-Core behavior receives test coverage. Edge cases including malformed API responses,
-empty arrays, and boundary conditions are deferred unless they cause production issues.
-Target is 90% coverage, not 100%. Focus on user-facing functionality.
-
-### Performance Micro-Optimizations
-
-Optimize when metrics show actual problems. Skipping unnecessary queries, adding
-theoretical indexes, or batching operations for minor latency gains without profiling
-data is premature optimization.
-
-### Documentation Enhancements
-
-Core documentation exists. Troubleshooting sections, rate limit documentation, and
-explanatory comments are iterative improvements based on user feedback. Perfect
-documentation delays shipping.
+Accessibility (ARIA labels, keyboard navigation, screen reader support) is a product
+priority decision that varies by project. Check project or user configuration for the
+team's stance. If no stance is declared, flag for user decision rather than assuming
+either way.

--- a/plugins/core/commands/address-pr-comments.md
+++ b/plugins/core/commands/address-pr-comments.md
@@ -16,8 +16,8 @@ If a suggestion would genuinely improve the code, fix it. Only decline when you 
 articulate why the bot is mistaken given context it lacks.
 
 Read @rules/code-review-standards.mdc for patterns where bot suggestions typically don't
-apply. Use these to identify incorrect suggestions - but always explain WHY the bot is
-wrong in this specific case, not just that the issue is "minor" or "not blocking."
+apply. Use these to identify incorrect suggestions - explain why the bot is wrong in
+this specific case, not just that the issue is "minor" or "not blocking."
 </objective>
 
 <usage>


### PR DESCRIPTION
## Summary

- Shifts triage philosophy from "skip things that aren't blocking" to "only decline when the bot is wrong"
- Addresses feedback that skipping "minor" issues just defers work to humans
- Follows prompt-engineering.mdc principles (positive framing, no anti-patterns shown)

## Changes

**address-pr-comments.md (v1.4.0 → v1.5.0):**
- Reworded objective to emphasize identifying incorrect suggestions, not prioritizing
- Simplified triage criteria to single question: "Is the bot's analysis correct?"
- Added guidance for partial correctness (bot identifies real issue, suggests wrong fix)
- Reframed hotfix-mode with positive language
- Removed `gh pr checks --watch` anti-pattern mention

**code-review-standards.mdc (v1.0.0 → v1.1.0):**
- Reframed core philosophy around correctness, not priority
- Simplified race condition and optimization sections
- Clarified accessibility as the one valid "flag for user" case (scope decision)
- Removed negative framing throughout

## Test Plan

- [ ] Run `/address-pr-comments` on a PR with mixed feedback to verify triage behavior
- [ ] Verify declines include reasoning about why bot is wrong (not just "minor")
- [ ] Check that valid suggestions get addressed regardless of size

🤖 Generated with [Claude Code](https://claude.com/claude-code)