### PR TITLE
✨ Add playwright-browser skill with progressive disclosure

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -15,7 +15,7 @@
       "name": "ai-coding-config",
       "source": "./plugins/core",
       "description": "Commands, agents, skills, and context for AI-assisted development workflows",
-      "version": "8.5.0",
+      "version": "8.6.0",
       "tags": ["commands", "agents", "skills", "workflows", "essential"]
     }
   ]

--- a/plugins/core/skills/playwright-browser/API_REFERENCE.md
+++ b/plugins/core/skills/playwright-browser/API_REFERENCE.md
@@ -1,0 +1,268 @@
+# Playwright Advanced Patterns
+
+Patterns beyond basics. For standard operations (click, fill, screenshot, selectors), use Playwright knowledge from training.
+
+## Network Interception
+
+### Mock API Responses
+
+```javascript
+await page.route('**/api/users', route => {
+  route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify([{ id: 1, name: 'Mock User' }])
+  });
+});
+
+// Modify requests
+await page.route('**/api/**', route => {
+  route.continue({
+    headers: { ...route.request().headers(), 'X-Test': 'true' }
+  });
+});
+
+// Block resources
+await page.route('**/*.{png,jpg,gif}', route => route.abort());
+```
+
+### Capture Network Traffic
+
+```javascript
+const requests = [];
+page.on('request', req => requests.push({ url: req.url(), method: req.method() }));
+page.on('response', res => console.log(res.status(), res.url()));
+
+// Wait for specific response
+const responsePromise = page.waitForResponse('**/api/data');
+await page.click('button');
+const response = await responsePromise;
+const data = await response.json();
+```
+
+## Authentication State Persistence
+
+```javascript
+// Save auth state after login
+await page.context().storageState({ path: '/tmp/auth.json' });
+
+// Reuse in new context
+const context = await browser.newContext({
+  storageState: '/tmp/auth.json'
+});
+```
+
+## Multi-Tab Handling
+
+```javascript
+// Wait for popup
+const [popup] = await Promise.all([
+  page.waitForEvent('popup'),
+  page.click('a[target="_blank"]')
+]);
+await popup.waitForLoadState();
+console.log(await popup.title());
+
+// Open new tab manually
+const newPage = await context.newPage();
+await newPage.goto('https://example.com');
+```
+
+## File Downloads
+
+```javascript
+const [download] = await Promise.all([
+  page.waitForEvent('download'),
+  page.click('button.download')
+]);
+
+const filePath = `/tmp/${download.suggestedFilename()}`;
+await download.saveAs(filePath);
+console.log('Downloaded to:', filePath);
+```
+
+## File Uploads
+
+```javascript
+// Single file
+await page.setInputFiles('input[type="file"]', '/tmp/test.pdf');
+
+// Multiple files
+await page.setInputFiles('input[type="file"]', ['/tmp/a.pdf', '/tmp/b.pdf']);
+
+// Clear files
+await page.setInputFiles('input[type="file"]', []);
+```
+
+## Video Recording
+
+```javascript
+const context = await browser.newContext({
+  recordVideo: {
+    dir: '/tmp/videos/',
+    size: { width: 1280, height: 720 }
+  }
+});
+
+const page = await context.newPage();
+// ... do things ...
+await page.close();
+
+const videoPath = await page.video().path();
+console.log('Video saved:', videoPath);
+```
+
+## Trace Recording (Debugging)
+
+```javascript
+// Start trace
+await context.tracing.start({ screenshots: true, snapshots: true });
+
+// ... do things ...
+
+// Save trace
+await context.tracing.stop({ path: '/tmp/trace.zip' });
+// View with: npx playwright show-trace /tmp/trace.zip
+```
+
+## iFrames
+
+```javascript
+const frame = page.frameLocator('#my-iframe');
+await frame.locator('button').click();
+await frame.locator('input').fill('text');
+```
+
+## Device Emulation
+
+```javascript
+const { devices } = require('playwright');
+
+// Use predefined device
+const context = await browser.newContext({
+  ...devices['iPhone 14']
+});
+
+// Or custom viewport
+const context = await browser.newContext({
+  viewport: { width: 375, height: 667 },
+  isMobile: true,
+  hasTouch: true
+});
+```
+
+## Geolocation
+
+```javascript
+const context = await browser.newContext({
+  geolocation: { latitude: 37.7749, longitude: -122.4194 },
+  permissions: ['geolocation']
+});
+```
+
+## Console and Error Capture
+
+```javascript
+page.on('console', msg => {
+  console.log(`[${msg.type()}] ${msg.text()}`);
+});
+
+page.on('pageerror', error => {
+  console.error('Page error:', error.message);
+});
+```
+
+## Custom Headers (Global)
+
+```javascript
+const context = await browser.newContext({
+  extraHTTPHeaders: {
+    'X-Automated-By': 'playwright-skill',
+    'Authorization': 'Bearer token'
+  }
+});
+```
+
+## Cookies
+
+```javascript
+// Set cookie
+await context.addCookies([{
+  name: 'session',
+  value: 'abc123',
+  domain: 'example.com',
+  path: '/'
+}]);
+
+// Get cookies
+const cookies = await context.cookies();
+
+// Clear cookies
+await context.clearCookies();
+```
+
+## localStorage/sessionStorage
+
+```javascript
+// Evaluate in page context
+await page.evaluate(() => {
+  localStorage.setItem('key', 'value');
+});
+
+const value = await page.evaluate(() => localStorage.getItem('key'));
+```
+
+## Wait Strategies
+
+```javascript
+// Wait for function to return true
+await page.waitForFunction(() => document.querySelector('.loaded') !== null);
+
+// Wait for specific response
+await page.waitForResponse(res =>
+  res.url().includes('/api/') && res.status() === 200
+);
+
+// Wait for navigation
+await Promise.all([
+  page.waitForNavigation(),
+  page.click('a.nav-link')
+]);
+```
+
+## Parallel Browser Contexts
+
+```javascript
+// Run multiple isolated sessions
+const [context1, context2] = await Promise.all([
+  browser.newContext(),
+  browser.newContext()
+]);
+
+const [page1, page2] = await Promise.all([
+  context1.newPage(),
+  context2.newPage()
+]);
+
+// Each has separate cookies, storage, etc.
+```
+
+## PDF Generation
+
+```javascript
+await page.pdf({
+  path: '/tmp/page.pdf',
+  format: 'A4',
+  printBackground: true
+});
+```
+
+## Dialogs (alert, confirm, prompt)
+
+```javascript
+page.on('dialog', async dialog => {
+  console.log('Dialog:', dialog.message());
+  await dialog.accept('input for prompt');
+  // or: await dialog.dismiss();
+});
+```

--- a/plugins/core/skills/playwright-browser/SKILL.md
+++ b/plugins/core/skills/playwright-browser/SKILL.md
@@ -36,21 +36,11 @@ $SKILL_DIR is where you loaded this file from.
 </execution>
 
 <headless-vs-headed>
-Default: headless (browser runs invisibly, less intrusive).
+Default: headless (invisible, less intrusive).
 
-Use headed (visible browser) when user says:
-- "show me", "watch", "let me see"
-- "debug", "what's happening"
-- "step through", "follow along"
+Use headed when user wants to see the browser. You know when that is.
 
-To run headed, set env var:
-```bash
-PLAYWRIGHT_HEADED=true node $SKILL_DIR/run.js /tmp/script.js
-```
-
-Or in the script: `chromium.launch({ headless: false })`
-
-Announce mode: "Running in headless mode" or "Opening visible browser..."
+For headed: `PLAYWRIGHT_HEADED=true` env var or `{ headless: false }` in script.
 </headless-vs-headed>
 
 <defaults>

--- a/plugins/core/skills/playwright-browser/SKILL.md
+++ b/plugins/core/skills/playwright-browser/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: playwright-browser
+description: "Use for browser automation, testing pages, screenshots, UX validation"
+version: 1.0.0
+category: testing
+triggers:
+  - "browser"
+  - "playwright"
+  - "screenshot"
+  - "test the page"
+  - "check the UI"
+  - "login flow"
+  - "fill form"
+  - "responsive"
+  - "viewport"
+---
+
+<objective>
+Browser automation via Playwright. Write scripts, execute via run.js.
+</objective>
+
+<execution>
+Write Playwright code to /tmp, execute from skill directory:
+
+```bash
+node $SKILL_DIR/run.js /tmp/playwright-task.js
+```
+
+For inline code (variables are auto-injected, see below):
+
+```bash
+node $SKILL_DIR/run.js "const b = await chromium.launch(); const p = await b.newPage(); await p.goto('http://localhost:3000'); console.log(await p.title()); await b.close();"
+```
+
+$SKILL_DIR is where you loaded this file from.
+</execution>
+
+<defaults>
+Screenshots to /tmp. Use `slowMo: 100` for visibility.
+</defaults>
+
+<injected-variables>
+For inline code, these are available:
+
+- `BASE_URL` - from PLAYWRIGHT_BASE_URL env var (empty string if not set)
+- `HEADLESS` - true in CI (GITHUB_ACTIONS, CI, etc.), false otherwise
+- `chromium`, `firefox`, `webkit`, `devices` - from playwright
+
+Example inline usage:
+```bash
+node $SKILL_DIR/run.js "
+const browser = await chromium.launch({ headless: HEADLESS });
+const page = await browser.newPage();
+await page.goto(BASE_URL || 'http://localhost:3000');
+console.log(await page.title());
+await browser.close();
+"
+```
+</injected-variables>
+
+<auto-install>
+run.js auto-installs Playwright on first use. No manual setup needed.
+</auto-install>
+
+<advanced-patterns>
+For network mocking, auth persistence, multi-tab, downloads, video, traces:
+[API_REFERENCE.md](API_REFERENCE.md)
+</advanced-patterns>

--- a/plugins/core/skills/playwright-browser/SKILL.md
+++ b/plugins/core/skills/playwright-browser/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: playwright-browser
-description: "Use for browser automation, testing pages, screenshots, UX validation"
+description: "Use when automating browsers, testing pages, or taking screenshots"
 version: 1.0.0
 category: testing
 triggers:

--- a/plugins/core/skills/playwright-browser/SKILL.md
+++ b/plugins/core/skills/playwright-browser/SKILL.md
@@ -35,21 +35,41 @@ node $SKILL_DIR/run.js "const b = await chromium.launch(); const p = await b.new
 $SKILL_DIR is where you loaded this file from.
 </execution>
 
+<headless-vs-headed>
+Default: headless (browser runs invisibly, less intrusive).
+
+Use headed (visible browser) when user says:
+- "show me", "watch", "let me see"
+- "debug", "what's happening"
+- "step through", "follow along"
+
+To run headed, set env var:
+```bash
+PLAYWRIGHT_HEADED=true node $SKILL_DIR/run.js /tmp/script.js
+```
+
+Or in the script: `chromium.launch({ headless: false })`
+
+Announce mode: "Running in headless mode" or "Opening visible browser..."
+</headless-vs-headed>
+
 <defaults>
-Screenshots to /tmp. Use `slowMo: 100` for visibility.
+Screenshots to /tmp. Use `slowMo: 100` for debugging.
 </defaults>
 
 <injected-variables>
 For inline code, these are available:
 
-- `BASE_URL` - from PLAYWRIGHT_BASE_URL env var (empty string if not set)
-- `HEADLESS` - true in CI (GITHUB_ACTIONS, CI, etc.), false otherwise
+- `BASE_URL` - from PLAYWRIGHT_BASE_URL env var
+- `HEADLESS` - true by default (set PLAYWRIGHT_HEADED=true for visible)
+- `CI_ARGS` - browser args for CI (`['--no-sandbox', '--disable-setuid-sandbox']`)
+- `EXTRA_HEADERS` - from PW_HEADER_NAME/VALUE or PW_EXTRA_HEADERS
 - `chromium`, `firefox`, `webkit`, `devices` - from playwright
 
-Example inline usage:
+Example:
 ```bash
 node $SKILL_DIR/run.js "
-const browser = await chromium.launch({ headless: HEADLESS });
+const browser = await chromium.launch({ headless: HEADLESS, args: CI_ARGS });
 const page = await browser.newPage();
 await page.goto(BASE_URL || 'http://localhost:3000');
 console.log(await page.title());

--- a/plugins/core/skills/playwright-browser/package.json
+++ b/plugins/core/skills/playwright-browser/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "playwright-browser-skill",
+  "version": "1.0.0",
+  "description": "Playwright browser automation skill for Claude Code",
+  "private": true,
+  "scripts": {
+    "setup": "npm install && npx playwright install chromium"
+  },
+  "dependencies": {
+    "playwright": "^1.49.0"
+  }
+}

--- a/plugins/core/skills/playwright-browser/run.js
+++ b/plugins/core/skills/playwright-browser/run.js
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+/**
+ * Playwright executor for Claude Code
+ *
+ * Usage:
+ *   node run.js script.js        - Execute file
+ *   node run.js "code here"      - Execute inline
+ *   cat script.js | node run.js  - Execute from stdin
+ *
+ * Auto-installs Playwright on first run.
+ * Properly awaits async code before exiting.
+ */
+
+const fs = require("fs");
+const path = require("path");
+const { execSync, spawn } = require("child_process");
+
+process.chdir(__dirname);
+
+function isCI() {
+  return !!(
+    process.env.CI ||
+    process.env.GITHUB_ACTIONS ||
+    process.env.GITLAB_CI ||
+    process.env.CIRCLECI ||
+    process.env.JENKINS_URL
+  );
+}
+
+function checkPlaywrightInstalled() {
+  try {
+    require.resolve("playwright");
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function installPlaywright() {
+  console.log("Installing Playwright...");
+  try {
+    execSync("npm install", { stdio: "inherit", cwd: __dirname });
+    execSync("npx playwright install chromium", {
+      stdio: "inherit",
+      cwd: __dirname,
+    });
+    console.log("Playwright ready");
+    return true;
+  } catch (e) {
+    console.error("Failed to install Playwright:", e.message);
+    return false;
+  }
+}
+
+function getCodeToExecute() {
+  const args = process.argv.slice(2);
+
+  if (args.length > 0 && fs.existsSync(args[0])) {
+    return { code: fs.readFileSync(path.resolve(args[0]), "utf8"), isFile: true };
+  }
+
+  if (args.length > 0) {
+    return { code: args.join(" "), isFile: false };
+  }
+
+  if (!process.stdin.isTTY) {
+    return { code: fs.readFileSync(0, "utf8"), isFile: false };
+  }
+
+  console.error("Usage: node run.js <file|code>");
+  process.exit(1);
+}
+
+function isCompleteScript(code) {
+  const hasRequire = code.includes("require(");
+  const hasAsyncWrapper =
+    code.includes("(async () =>") ||
+    code.includes("(async()=>") ||
+    code.includes("(async function");
+  return hasRequire && hasAsyncWrapper;
+}
+
+function wrapInlineCode(code) {
+  const headless = isCI();
+
+  return `
+const { chromium, firefox, webkit, devices } = require('playwright');
+
+const BASE_URL = process.env.PLAYWRIGHT_BASE_URL || '';
+const HEADLESS = ${headless};
+
+(async () => {
+  try {
+    ${code}
+  } catch (error) {
+    console.error('Error:', error.message);
+    if (error.stack) console.error(error.stack);
+    process.exit(1);
+  }
+})();
+`;
+}
+
+function runScript(scriptPath) {
+  return new Promise((resolve, reject) => {
+    const child = spawn("node", [scriptPath], {
+      stdio: "inherit",
+      cwd: __dirname,
+      env: process.env,
+    });
+
+    child.on("close", (code) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`Script exited with code ${code}`));
+      }
+    });
+
+    child.on("error", reject);
+  });
+}
+
+async function main() {
+  if (!checkPlaywrightInstalled()) {
+    if (!installPlaywright()) {
+      process.exit(1);
+    }
+  }
+
+  const { code, isFile } = getCodeToExecute();
+
+  // For complete scripts, run them directly with node
+  // This properly waits for async code to complete
+  if (isCompleteScript(code)) {
+    const tempFile = path.join(__dirname, `.temp-${Date.now()}.js`);
+    try {
+      fs.writeFileSync(tempFile, code, "utf8");
+      await runScript(tempFile);
+    } finally {
+      try {
+        fs.unlinkSync(tempFile);
+      } catch {}
+    }
+    return;
+  }
+
+  // For inline code, wrap it and run
+  const wrappedCode = wrapInlineCode(code);
+  const tempFile = path.join(__dirname, `.temp-${Date.now()}.js`);
+
+  try {
+    fs.writeFileSync(tempFile, wrappedCode, "utf8");
+    await runScript(tempFile);
+  } finally {
+    try {
+      fs.unlinkSync(tempFile);
+    } catch {}
+  }
+}
+
+main().catch((error) => {
+  console.error("Fatal:", error.message);
+  process.exit(1);
+});

--- a/plugins/core/skills/playwright-browser/run.js
+++ b/plugins/core/skills/playwright-browser/run.js
@@ -88,14 +88,18 @@ function cleanupOldTempFiles() {
 function getCodeToExecute() {
   const args = process.argv.slice(2);
 
-  if (args.length > 0 && fs.existsSync(args[0])) {
-    const filePath = path.resolve(args[0]);
-    console.log(`📄 Executing: ${filePath}`);
-    return fs.readFileSync(filePath, "utf8");
-  }
-
   if (args.length > 0) {
-    console.log("⚡ Executing inline code");
+    if (fs.existsSync(args[0])) {
+      const filePath = path.resolve(args[0]);
+      console.log(`📄 Executing: ${filePath}`);
+      return fs.readFileSync(filePath, "utf8");
+    }
+    // Warn if it looks like a file path but doesn't exist
+    if (args[0].endsWith(".js") || args[0].includes("/")) {
+      console.warn(`⚠️  '${args[0]}' not found, treating as inline code`);
+    } else {
+      console.log("⚡ Executing inline code");
+    }
     return args.join(" ");
   }
 
@@ -137,7 +141,10 @@ function getExtraHeaders() {
       if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
         return parsed;
       }
-    } catch {}
+      console.warn('⚠️  PW_EXTRA_HEADERS must be a JSON object, ignoring');
+    } catch (e) {
+      console.warn('⚠️  PW_EXTRA_HEADERS is invalid JSON:', e.message);
+    }
   }
   return null;
 }


### PR DESCRIPTION
## Summary

- Replaces bloated Playwright MCP (~16.5k tokens) with a minimal skill that costs near-zero until invoked
- SKILL.md is 68 lines vs 454 in lackeyjb/playwright-skill
- Progressive disclosure pattern: tiny description for triggering, full docs when loaded

## Changes

**New skill at `plugins/core/skills/playwright-browser/`:**

- `SKILL.md` - Minimal execution pattern, no examples Claude already knows from training
- `run.js` - Universal executor with auto-install, CI detection, proper async handling
- `package.json` - Playwright dependency
- `API_REFERENCE.md` - Advanced patterns only (network mocking, auth persistence, multi-tab, downloads, video, traces)

## Design Decisions

| Decision | Rationale |
|----------|-----------|
| No dev server detection with prompts | Breaks autonomous workflows. Use `PLAYWRIGHT_BASE_URL` env var instead |
| Visible browser by default | Better for debugging. CI detection auto-enables headless |
| spawn() for script execution | Properly awaits async code before process exit |
| Injected variables for inline code | `BASE_URL`, `HEADLESS`, `chromium`, etc. available without boilerplate |
| Skip basic API examples | Claude knows Playwright from training - don't waste tokens teaching it |

## Testing

- Code review agent verified no critical bugs
- Prompt engineer reviewed SKILL.md against prompt engineering standards
- Fixed async execution issue caught during review

🤖 Generated with [Claude Code](https://claude.com/claude-code)