### PR TITLE
Add commands from carmenta

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional AI coding configurations, agents, skills, and context for Claude Code and Cursor",
-    "version": "9.13.0",
+    "version": "9.14.0",
     "license": "MIT",
     "repository": "https://github.com/TechNickAI/ai-coding-config"
   },
@@ -15,7 +15,7 @@
       "name": "ai-coding-config",
       "source": "./plugins/core",
       "description": "Commands, agents, skills, and context for AI-assisted development workflows",
-      "version": "9.13.0",
+      "version": "9.14.0",
       "tags": ["commands", "agents", "skills", "workflows", "essential"]
     }
   ]

--- a/plugins/core/.claude-plugin/plugin.json
+++ b/plugins/core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-coding-config",
-  "version": "9.13.0",
+  "version": "9.14.0",
   "description": "Commands, agents, skills, and context for AI-assisted development workflows",
   "author": {
     "name": "TechNickAI",

--- a/plugins/core/commands/do-issue.md
+++ b/plugins/core/commands/do-issue.md
@@ -27,6 +27,22 @@ Either a PR ready for merge resolving the issue, or a well-explained triage deci
 /do-issue 123       # Explicit issue number
 ```
 
+<branch-detection>
+If no issue number provided, extract from current branch name using `git branch --show-current`.
+
+Match patterns in order (extract first capture group):
+- `do-issue-(\d+)`
+- `fix-issue-(\d+)`
+- `issue-(\d+)`
+- `fix-(\d+)`
+
+If no match or not on a branch, prompt user for issue number. Validate it's a positive integer before proceeding.
+</branch-detection>
+
+## Input Validation
+
+Before using issue/PR numbers in commands, verify it's a positive integer. Always pass as quoted arguments to prevent command injection: `gh issue view "$issue_num"`. Never use unquoted variables or string interpolation.
+
 ## GitHub Interaction
 
 Use `gh` CLI for all GitHub operations. Use reactions to communicate progress: 👀 when
@@ -51,8 +67,7 @@ appropriate. Done.
 For Fix: continue to implementation. </triage>
 
 <prepare>
-When proceeding with a fix: self-assign the issue, add in-progress label if available,
-add 🚀 reaction, and comment with your implementation approach (2-3 bullets).
+When proceeding with a fix: add 🚀 reaction, add in-progress label if available, and comment with your implementation approach (2-3 bullets). Note: AI assistants cannot assign issues to themselves via the GitHub API.
 </prepare>
 
 <implement>

--- a/plugins/core/commands/do-issue.md
+++ b/plugins/core/commands/do-issue.md
@@ -1,8 +1,7 @@
 ---
-name: do-issue
 # prettier-ignore
-description: Autonomously triage and resolve a GitHub issue from analysis to merged PR - handles investigation, fixes, testing, and PR workflow
-argument-hint: [issue-number]
+description: "Autonomously triage and resolve a GitHub issue from analysis to merged PR - handles investigation, fixes, testing, and PR workflow"
+argument-hint: "[issue-number]"
 version: 1.0.0
 ---
 
@@ -41,8 +40,6 @@ core request, user impact, and requirements. Add 👀 reaction.
 </fetch-and-analyze>
 
 <triage>
-Evaluate the issue following @.cursor/rules/issue-triage.mdc guidelines.
-
 Decide autonomously: Fix, Won't Fix, Need More Info, or Invalid.
 
 Show your decision and rationale briefly. Be professional and thoughtful - these are
@@ -119,5 +116,4 @@ Uses existing commands:
 
 Follows existing rules:
 
-- `@.cursor/rules/issue-triage.mdc` - Triage decisions
-- `@.cursor/rules/git-commit-message.mdc` - Commit formatting (via /autotask)
+- `@rules/git-commit-message.mdc` - Commit formatting (via /autotask)

--- a/plugins/core/commands/do-issue.md
+++ b/plugins/core/commands/do-issue.md
@@ -39,10 +39,6 @@ Match patterns in order (extract first capture group):
 If no match or not on a branch, prompt user for issue number. Validate it's a positive integer before proceeding.
 </branch-detection>
 
-## Input Validation
-
-Before using issue/PR numbers in commands, verify it's a positive integer. Always pass as quoted arguments to prevent command injection: `gh issue view "$issue_num"`. Never use unquoted variables or string interpolation.
-
 ## GitHub Interaction
 
 Use `gh` CLI for all GitHub operations. Use reactions to communicate progress: 👀 when

--- a/plugins/core/commands/do-issue.md
+++ b/plugins/core/commands/do-issue.md
@@ -1,6 +1,6 @@
 ---
 # prettier-ignore
-description: "Autonomously triage and resolve a GitHub issue from analysis to merged PR - handles investigation, fixes, testing, and PR workflow"
+description: "Autonomously triage and resolve a GitHub issue from analysis to PR ready for merge - handles investigation, fixes, testing, and PR workflow"
 argument-hint: "[issue-number]"
 version: 1.0.0
 ---
@@ -8,7 +8,7 @@ version: 1.0.0
 # /do-issue - Autonomous Issue Resolution
 
 <objective>
-Take a GitHub issue from initial triage to merged PR, handling the complete lifecycle autonomously. Triage professionally, implement efficiently, deliver production-ready code.
+Take a GitHub issue from initial triage to PR ready for merge, handling the complete lifecycle autonomously. Triage professionally, implement efficiently, deliver production-ready code.
 </objective>
 
 <user-provides>
@@ -16,7 +16,7 @@ Issue number (or auto-detect from current branch)
 </user-provides>
 
 <command-delivers>
-Either a merged PR resolving the issue, or a well-explained triage decision closing it.
+Either a PR ready for merge resolving the issue, or a well-explained triage decision closing it.
 </command-delivers>
 
 ## Usage

--- a/plugins/core/commands/do-issue.md
+++ b/plugins/core/commands/do-issue.md
@@ -1,0 +1,123 @@
+---
+name: do-issue
+# prettier-ignore
+description: Autonomously triage and resolve a GitHub issue from analysis to merged PR - handles investigation, fixes, testing, and PR workflow
+argument-hint: [issue-number]
+version: 1.0.0
+---
+
+# /do-issue - Autonomous Issue Resolution
+
+<objective>
+Take a GitHub issue from initial triage to merged PR, handling the complete lifecycle autonomously. Triage professionally, implement efficiently, deliver production-ready code.
+</objective>
+
+<user-provides>
+Issue number (or auto-detect from current branch)
+</user-provides>
+
+<command-delivers>
+Either a merged PR resolving the issue, or a well-explained triage decision closing it.
+</command-delivers>
+
+## Usage
+
+```
+/do-issue           # Auto-detect from branch name
+                    # Patterns: do-issue-123, fix-issue-123, issue-123, fix-123
+/do-issue 123       # Explicit issue number
+```
+
+## GitHub Interaction
+
+Use `gh` CLI for all GitHub operations. Use reactions to communicate progress: 👀 when
+analyzing, 🚀 when starting work, ❤️ on helpful user comments.
+
+## Workflow
+
+<fetch-and-analyze>
+Fetch the issue with `gh`. Check for existing PRs, assignees, and state. Extract the
+core request, user impact, and requirements. Add 👀 reaction.
+</fetch-and-analyze>
+
+<triage>
+Evaluate the issue following @.cursor/rules/issue-triage.mdc guidelines.
+
+Decide autonomously: Fix, Won't Fix, Need More Info, or Invalid.
+
+Show your decision and rationale briefly. Be professional and thoughtful - these are
+real users contributing to the project.
+
+For Won't Fix, Need Info, or Invalid: update the issue with explanation and close if
+appropriate. Done.
+
+For Fix: continue to implementation. </triage>
+
+<prepare>
+When proceeding with a fix: self-assign the issue, add in-progress label if available,
+add 🚀 reaction, and comment with your implementation approach (2-3 bullets).
+</prepare>
+
+<implement>
+Use /autotask to implement the fix. Ensure the PR description includes "Fixes #{number}"
+so GitHub auto-links and closes the issue when merged.
+</implement>
+
+<polish>
+Use /address-pr-comments to handle bot feedback autonomously.
+
+This gets the PR to "ready to merge" state without human intervention for bot-related
+feedback. </polish>
+
+<finalize>
+Comment on the issue with the PR link. Add ❤️ to helpful user comments. The issue
+auto-closes when the PR merges due to the "Fixes #" keyword.
+</finalize>
+
+## Progress Tracking
+
+Use TodoWrite to track workflow phases. Create todos at the start, update status as you
+progress. The goal is transparency and ensuring you complete all phases.
+
+## Edge Cases
+
+If assigned to someone else, ask before taking over. If a PR already exists, skip if
+active or ask if stale (7+ days). If closed, ask before reopening.
+
+## Completion Criteria
+
+You're done when:
+
+- Issue is triaged with clear decision documented
+- If fixing: PR is created, bot feedback addressed, and PR is ready to merge
+- If not fixing: Issue is updated with explanation
+- Issue is properly linked to PR (if fixing)
+- All todos are marked completed
+
+Don't stop mid-workflow. The todos help ensure you complete all phases.
+
+## Error Recovery
+
+If /autotask or /address-pr-comments fail, evaluate recoverability. Transient errors
+(API failures, missing dependencies): retry with additional context. Fundamental
+blockers (architectural issues, unclear requirements): comment on the issue explaining
+the blocker and ask for guidance. Never silently abandon the workflow.
+
+## Key Principles
+
+Autonomous but transparent: make decisions independently, document them clearly.
+Professional communication: users took time to file issues, treat them with respect.
+Bias toward action: move quickly to implementation or explain thoughtfully why not.
+Complete the cycle: deliver the PR or close with explanation, never leave half-done.
+
+## Integration Points
+
+Uses existing commands:
+
+- `/autotask` - Implementation and PR creation
+- `/address-pr-comments` - Bot feedback handling
+
+Follows existing rules:
+
+- `@.cursor/rules/issue-triage.mdc` - Triage decisions
+- `@.cursor/rules/git-commit-message.mdc` - Commit formatting (via /autotask)

--- a/plugins/core/commands/upgrade-deps.md
+++ b/plugins/core/commands/upgrade-deps.md
@@ -34,14 +34,6 @@ $ARGUMENTS
 
 If no argument provided, scan all dependencies.
 
-## Input Validation
-
-Before using package names in commands, validate format and always quote:
-- **JavaScript**: `^(@[a-z0-9-~][a-z0-9-._~]*/)?[a-z0-9-~][a-z0-9-._~]*$`
-- **Python**: `^[a-zA-Z0-9]([a-zA-Z0-9._-]*[a-zA-Z0-9])?$`
-
-Always pass as quoted arguments: `pnpm update "$pkg_name"`. Never use unquoted variables to prevent command injection.
-
 ## Ecosystem Detection
 
 <ecosystem-detection>

--- a/plugins/core/commands/upgrade-deps.md
+++ b/plugins/core/commands/upgrade-deps.md
@@ -1,8 +1,7 @@
 ---
-name: upgrade-deps
 # prettier-ignore
-description: Scan dependencies for updates, discover new features from changelogs, implement quick wins, create issues for larger opportunities - transforms maintenance into capability expansion
-argument-hint: [package-name?]
+description: "Scan dependencies for updates, discover new features from changelogs, implement quick wins, create issues for larger opportunities - transforms maintenance into capability expansion"
+argument-hint: "[package-name?]"
 version: 1.0.0
 ---
 

--- a/plugins/core/commands/upgrade-deps.md
+++ b/plugins/core/commands/upgrade-deps.md
@@ -34,6 +34,14 @@ $ARGUMENTS
 
 If no argument provided, scan all dependencies.
 
+## Input Validation
+
+Before using package names in commands, validate format and always quote:
+- **JavaScript**: `^(@[a-z0-9-~][a-z0-9-._~]*/)?[a-z0-9-~][a-z0-9-._~]*$`
+- **Python**: `^[a-zA-Z0-9]([a-zA-Z0-9._-]*[a-zA-Z0-9])?$`
+
+Always pass as quoted arguments: `pnpm update "$pkg_name"`. Never use unquoted variables to prevent command injection.
+
 ## Ecosystem Detection
 
 <ecosystem-detection>
@@ -133,7 +141,12 @@ For each package (or batch of related packages), update it then verify with type
 checking and tests. If either verification fails, stop immediately—report which package
 caused the failure and the specific errors. The user needs to decide how to proceed.
 
-If checks pass, continue to the next package. </update-loop>
+If checks pass, continue to the next package.
+
+After all updates complete, run a final batch verification (type check + tests) with all
+updates applied together. This catches cross-package conflicts that sequential testing
+missed—package A might pass alone, package B might pass alone, but A+B together could be
+incompatible. </update-loop>
 
 <feature-implementation>
 After successful updates, evaluate discovered opportunities:

--- a/plugins/core/commands/upgrade-deps.md
+++ b/plugins/core/commands/upgrade-deps.md
@@ -1,0 +1,274 @@
+---
+name: upgrade-deps
+# prettier-ignore
+description: Scan dependencies for updates, discover new features from changelogs, implement quick wins, create issues for larger opportunities - transforms maintenance into capability expansion
+argument-hint: [package-name?]
+version: 1.0.0
+---
+
+# /upgrade-deps - Dependency Discovery & Update
+
+<objective>
+Transform dependency updates from maintenance chores into feature discovery opportunities.
+Scan outdated packages, analyze changelogs for new capabilities relevant to our codebase,
+update with verification at each step, implement quick wins, and create issues for larger
+opportunities.
+</objective>
+
+<value-proposition>
+This is not about "is it safe to update" — tests are the safety net. This is about
+discovering what we can BUILD with new versions. Every update is a chance to adopt
+better APIs, remove workarounds, and expand capabilities.
+</value-proposition>
+
+## Usage
+
+```
+/upgrade-deps              # Scan and update all outdated packages
+/upgrade-deps react        # Update specific package only
+/upgrade-deps @tanstack/*  # Update packages matching pattern
+```
+
+## Arguments
+
+$ARGUMENTS
+
+If no argument provided, scan all dependencies.
+
+## Ecosystem Detection
+
+<ecosystem-detection>
+Detect the package manager from project files:
+
+**JavaScript/TypeScript:**
+
+- `package.json` + `pnpm-lock.yaml` → pnpm
+- `package.json` + `package-lock.json` → npm
+- `package.json` + `yarn.lock` → yarn
+- `package.json` + `bun.lockb` → bun
+
+**Python:**
+
+- `pyproject.toml` with `[tool.poetry]` → poetry
+- `pyproject.toml` with `[tool.uv]` or `uv.lock` → uv
+- `pyproject.toml` (generic) → pip with pyproject.toml
+- `requirements.txt` → pip
+
+If multiple ecosystems detected (e.g., both package.json and pyproject.toml), process
+each ecosystem separately, starting with the one containing the specified package
+argument or asking which to update if no argument provided. </ecosystem-detection>
+
+<tooling-matrix>
+| Operation | pnpm | npm | yarn | bun | pip | poetry | uv |
+|-----------|------|-----|------|-----|-----|--------|-----|
+| Outdated | `pnpm outdated` | `npm outdated` | `yarn outdated` or `yarn up -i` (v2+) | `bun outdated` | `pip list --outdated` | `poetry show --outdated` | `uv pip list --outdated` |
+| Install | `pnpm install` | `npm install` | `yarn install` | `bun install` | `pip install .` or `-r requirements.txt` | `poetry install` | `uv sync` |
+| Update one | `pnpm update {pkg}` | `npm update {pkg}` | `yarn upgrade {pkg}` (v1) or `yarn up {pkg}` (v2+) | `bun update {pkg}` | `pip install --upgrade {pkg}` | `poetry update {pkg}` | `uv add {pkg}@latest` |
+| Type check | `pnpm tsc --noEmit` | `npx tsc --noEmit` | `yarn tsc --noEmit` | `bun tsc --noEmit` | `mypy .` (if configured) | `mypy .` | `mypy .` |
+| Tests | `pnpm test` | `npm test` | `yarn test` | `bun test` | `pytest` | `pytest` | `pytest` |
+
+**Note on Yarn versions:** Detect Yarn classic vs Berry/v2+ by checking `yarn.lock` for
+`__metadata` field. Classic uses `yarn upgrade`, Berry uses `yarn up`.
+
+**Note on pip install:** Check for `requirements.txt` first. If absent but
+`pyproject.toml` exists, use `pip install .` for pyproject-only projects.
+</tooling-matrix>
+
+## Workflow
+
+<scan>
+Before starting updates, verify the baseline: run type check and tests to confirm they
+pass. If either fails, note this and ask how to proceed—updating on a broken baseline
+makes it impossible to isolate which update caused issues.
+
+Identify all packages with available updates using the appropriate outdated command.
+Group by update type:
+
+- Patch: Bug fixes only (1.2.3 → 1.2.4)
+- Minor: New features, backward-compatible (1.2.3 → 1.3.0)
+- Major: Breaking changes possible (1.2.3 → 2.0.0)
+
+Identify related packages that should update together to avoid version mismatches.
+</scan>
+
+<changelog-analysis>
+For each outdated package, fetch the changelog between our current version and the latest:
+
+Primary sources (in order of preference):
+
+- GitHub Releases API: `gh api repos/{owner}/{repo}/releases`
+- CHANGELOG.md in the repository
+- PyPI/npm package page release notes
+
+Extract and categorize:
+
+- New features and APIs we could adopt
+- Deprecations affecting code we use
+- Bug fixes relevant to our usage patterns
+- Breaking changes requiring migration
+
+For bug fixes: Scan our codebase for usage of the affected code paths. Report only bugs
+that actually impacted us, not every fix in the changelog.
+
+For new features: Identify where our code could benefit. Look for patterns like:
+
+- Manual implementations that the library now handles
+- Workarounds for issues now fixed
+- New APIs that simplify existing code </changelog-analysis>
+
+<confirmation-gates>
+Proceed automatically for patch and minor updates.
+
+Pause and confirm before:
+
+- Major version updates
+- Updates with breaking changes in the changelog
+- Updates to core dependencies (react, next, typescript, django, fastapi, sqlalchemy)
+- Updates where the changelog indicates significant API changes
+
+Present: Current version, target version, summary of changes, any code modifications
+that may be needed. </confirmation-gates>
+
+<update-loop>
+For each package (or batch of related packages), update it then verify with type
+checking and tests. If either verification fails, stop immediately—report which package
+caused the failure and the specific errors. The user needs to decide how to proceed.
+
+If checks pass, continue to the next package. </update-loop>
+
+<feature-implementation>
+After successful updates, evaluate discovered opportunities:
+
+Quick wins (implement inline):
+
+- New API that directly replaces existing code
+- Simplified syntax for patterns we already use
+- Removal of workarounds for fixed bugs
+- Single-file changes with clear before/after (roughly 20 lines or fewer)
+
+Medium scope (create GitHub issue):
+
+- New features requiring architectural consideration
+- Deprecation migrations affecting multiple files
+- Performance improvements requiring measurement
+- New capabilities we should adopt but need planning
+
+For each GitHub issue created, include:
+
+- Link to the relevant changelog entry
+- Files in our codebase that would be affected
+- Suggested implementation approach
+- Link to new documentation </feature-implementation>
+
+<commit-strategy>
+One PR per command invocation.
+
+Commit granularity:
+
+- Batch commit for patch/minor updates with no code changes:
+  `chore(deps): update patch/minor dependencies`
+- Separate commit when implementing a feature from an upgrade:
+  `feat(deps): update {package} to v{version} - {what was implemented}`
+- Separate commit for breaking change migrations:
+  `refactor(deps): migrate to {package} v{version} API`
+
+Each commit should pass type check and tests independently. </commit-strategy>
+
+## Final Report
+
+<report-structure>
+Present a summary when complete:
+
+**Packages Updated** Table: Package | Previous | Current | Change Type
+
+**New Features Available** For each update with new capabilities:
+
+- What's new (link to docs)
+- How it applies to our codebase
+- Whether it was implemented or deferred
+
+**Bugs Fixed That Affected Us** Only bugs where we use the affected code paths:
+
+- What was broken
+- Where we use it
+- Confirmation it's resolved
+
+**Quick Wins Implemented** What was adopted inline during this update.
+
+**GitHub Issues Created** Links to issues for larger opportunities.
+
+**Deprecation Warnings** APIs we use that are now deprecated, with migration timeline.
+</report-structure>
+
+## Related Package Groups
+
+Handle these as atomic updates to avoid version mismatches:
+
+**JavaScript/TypeScript:**
+
+```
+@tanstack/react-query, @tanstack/react-query-devtools
+@radix-ui/* (when updating any Radix component)
+eslint, @typescript-eslint/*, eslint-config-*
+@testing-library/react, @testing-library/jest-dom
+next, @next/*
+```
+
+**Python:**
+
+```
+sqlalchemy, alembic
+django, django-*
+fastapi, starlette, pydantic
+pytest, pytest-*
+mypy, types-*
+```
+
+## Edge Cases
+
+<no-changelog>
+If a package has no discoverable changelog, proceed with the update but note it in the
+report. Rely on type check and tests to catch issues.
+</no-changelog>
+
+<pre-existing-failures>
+If type check or tests fail BEFORE any updates, note this and ask how to proceed.
+Updating on a broken baseline makes it impossible to isolate which update caused issues.
+</pre-existing-failures>
+
+<monorepo-packages>
+For monorepo packages (multiple packages from same repo), fetch the changelog once and
+apply relevant entries to each package being updated.
+</monorepo-packages>
+
+<mixed-ecosystem-projects>
+For projects with both JS and Python dependencies, process one ecosystem at a time.
+Complete all updates for one ecosystem before starting the other. This keeps the
+verification loop clean and isolates cross-ecosystem issues.
+</mixed-ecosystem-projects>
+
+## Progress Tracking
+
+Use TodoWrite to track:
+
+- Packages to update (with version info)
+- Changelog analysis status
+- Update and verification status
+- Feature implementation status
+- GitHub issues to create
+
+This provides visibility into progress for long-running updates across many packages.
+
+## Key Principles
+
+Tests are the safety net, not "safety theater" checks. If tests pass, the update is
+good.
+
+Feature discovery is the primary value. Every dependency update is a chance to improve
+the codebase, not just bump version numbers.
+
+Isolation through sequential verification. Check after each update so failures point to
+the specific package that broke things.
+
+Actionable output. The final report should make it clear what changed, what's possible
+now, and what to do next.

--- a/plugins/core/commands/wrap-up.md
+++ b/plugins/core/commands/wrap-up.md
@@ -1,0 +1,97 @@
+---
+name: wrap-up
+# prettier-ignore
+description: "Merge PR, sync local to main, clean up branch - the satisfying end to a feature workflow"
+argument-hint: [pr-number]
+model: haiku
+version: 1.0.1
+---
+
+# /wrap-up - Complete the Feature Workflow
+
+<objective>
+Merge the PR, sync local state to main, clean up the feature branch, and celebrate the
+accomplishment. This is the final step after /autotask and /address-pr-comments.
+</objective>
+
+## Usage
+
+```
+/wrap-up        - Auto-detect PR from current branch
+/wrap-up 123    - Wrap up PR #123
+```
+
+<pr-detection>
+Find the PR from the argument or current branch. If no PR exists or it's already closed,
+inform user and exit.
+</pr-detection>
+
+<merge-readiness>
+Check that the PR can be merged (no conflicts, not blocked). If CI is failing, warn but
+proceed - user has context we don't.
+
+If blocked by conflicts or missing approvals, tell user what's blocking and exit.
+</merge-readiness>
+
+<merge-and-cleanup>
+Use `gh pr merge --merge --delete-branch` for the merge.
+
+This single command handles everything:
+
+1. Merges the PR with a merge commit
+2. Deletes the remote branch
+3. Switches to main and pulls merged changes
+4. Deletes the local branch automatically
+
+Do NOT attempt to delete the local branch manually - `--delete-branch` already did it.
+You'll get "branch not found" errors if you try. </merge-and-cleanup>
+
+<completion-state>
+After merge, show clear state so Nick knows exactly where he is when he context-switches
+back to this terminal later.
+
+Detect current state:
+
+- Is this a worktree? (check `git worktree list`)
+- What's the absolute path?
+- Where's the main repo?
+
+**If in a worktree (common case after /autotask):**
+
+```
+✓ PR #123 "Add wrap-up command" merged to main
+
+You're in: {worktree-path} (worktree, now orphaned)
+Main repo: {main-repo-path}
+
+→ git worktree remove . (from main repo) to clean up
+→ cd {main-repo-path} to continue there
+```
+
+**If in main repo:**
+
+```
+✓ PR #123 "Add wrap-up command" merged to main
+
+On main at {repo-path}, up to date.
+```
+
+The value is clarity of state, not celebration. Brief, informative, shows next options.
+
+Language precision: Say "merged to main" not "live" or "deployed". Merged means it's in
+the codebase. Live/deployed means running in production - requires CI to pass and deploy
+to complete. Don't conflate these. </completion-state>
+
+<error-messages>
+PR not found: Guide user to create one.
+Not mergeable: Point to `/address-pr-comments`.
+Already merged: Just sync local state.
+CI failing: Warn but allow proceeding.
+</error-messages>
+
+## Key Behaviors
+
+- Merge commit preserves full branch history
+- `--delete-branch` handles both remote and local branch cleanup automatically
+- Worktrees preserved for user to clean up when ready
+- Output prioritizes state clarity for context-switching back later

--- a/plugins/core/commands/wrap-up.md
+++ b/plugins/core/commands/wrap-up.md
@@ -20,10 +20,6 @@ accomplishment. This is the final step after /autotask and /address-pr-comments.
 /wrap-up 123    - Wrap up PR #123
 ```
 
-## Input Validation
-
-Before using PR numbers in commands, verify it's a positive integer. Always pass as quoted arguments: `gh pr view "$pr_num"`. Never use unquoted variables to prevent command injection.
-
 <pr-detection>
 Find the PR from the argument or current branch. If no PR exists or it's already closed,
 inform user and exit.

--- a/plugins/core/commands/wrap-up.md
+++ b/plugins/core/commands/wrap-up.md
@@ -46,7 +46,7 @@ Do NOT attempt to delete the local branch manually - `--delete-branch` already d
 You'll get "branch not found" errors if you try. </merge-and-cleanup>
 
 <completion-state>
-After merge, show clear state so the user knows exactly where they are when they context-switch
+After merge, show clear state so we know exactly where we are when context-switching
 back to this terminal later.
 
 Detect current state:

--- a/plugins/core/commands/wrap-up.md
+++ b/plugins/core/commands/wrap-up.md
@@ -3,7 +3,7 @@
 description: "Merge PR, sync local to main, clean up branch - the satisfying end to a feature workflow"
 argument-hint: "[pr-number]"
 model: haiku
-version: 1.0.1
+version: 1.0.0
 ---
 
 # /wrap-up - Complete the Feature Workflow

--- a/plugins/core/commands/wrap-up.md
+++ b/plugins/core/commands/wrap-up.md
@@ -1,8 +1,7 @@
 ---
-name: wrap-up
 # prettier-ignore
 description: "Merge PR, sync local to main, clean up branch - the satisfying end to a feature workflow"
-argument-hint: [pr-number]
+argument-hint: "[pr-number]"
 model: haiku
 version: 1.0.1
 ---
@@ -47,7 +46,7 @@ Do NOT attempt to delete the local branch manually - `--delete-branch` already d
 You'll get "branch not found" errors if you try. </merge-and-cleanup>
 
 <completion-state>
-After merge, show clear state so Nick knows exactly where he is when he context-switches
+After merge, show clear state so the user knows exactly where they are when they context-switch
 back to this terminal later.
 
 Detect current state:

--- a/plugins/core/commands/wrap-up.md
+++ b/plugins/core/commands/wrap-up.md
@@ -20,6 +20,10 @@ accomplishment. This is the final step after /autotask and /address-pr-comments.
 /wrap-up 123    - Wrap up PR #123
 ```
 
+## Input Validation
+
+Before using PR numbers in commands, verify it's a positive integer. Always pass as quoted arguments: `gh pr view "$pr_num"`. Never use unquoted variables to prevent command injection.
+
 <pr-detection>
 Find the PR from the argument or current branch. If no PR exists or it's already closed,
 inform user and exit.
@@ -33,17 +37,17 @@ If blocked by conflicts or missing approvals, tell user what's blocking and exit
 </merge-readiness>
 
 <merge-and-cleanup>
-Use `gh pr merge --merge --delete-branch` for the merge.
+Use `gh pr merge --merge --delete-branch` to merge with a merge commit and delete the remote branch.
 
-This single command handles everything:
+The local branch remains - clean it up after merge:
 
-1. Merges the PR with a merge commit
-2. Deletes the remote branch
-3. Switches to main and pulls merged changes
-4. Deletes the local branch automatically
+```bash
+git checkout main
+git pull
+git branch -d {branch-name}  # Safe delete - ensures already merged
+```
 
-Do NOT attempt to delete the local branch manually - `--delete-branch` already did it.
-You'll get "branch not found" errors if you try. </merge-and-cleanup>
+If currently in a worktree, the worktree directory persists for manual cleanup when ready. </merge-and-cleanup>
 
 <completion-state>
 After merge, show clear state so we know exactly where we are when context-switching


### PR DESCRIPTION
## Summary

Brings over generic commands from carmenta:

- **upgrade-deps**: Transform dependency updates into feature discovery - scans outdated packages, analyzes changelogs, implements quick wins
- **do-issue**: Autonomously triage and resolve GitHub issues from analysis to merged PR
- **wrap-up**: Merge PR, sync local to main, clean up branch - the satisfying end to a feature workflow

Also removed `/verify` from carmenta (unused) and genericized hardcoded paths in wrap-up.

## Test plan
- [ ] Verify YAML frontmatter is valid
- [ ] Test commands are discoverable in Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)