### PR TITLE
✨ Add todo persistence hooks to survive context compaction

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Professional AI coding configurations, agents, skills, and context for Claude Code and Cursor",
-    "version": "9.14.0",
+    "version": "9.15.0",
     "license": "MIT",
     "repository": "https://github.com/TechNickAI/ai-coding-config"
   },
@@ -15,7 +15,7 @@
       "name": "ai-coding-config",
       "source": "./plugins/core",
       "description": "Commands, agents, skills, and context for AI-assisted development workflows",
-      "version": "9.14.0",
+      "version": "9.15.0",
       "tags": ["commands", "agents", "skills", "workflows", "essential"]
     }
   ]

--- a/README.md
+++ b/README.md
@@ -40,6 +40,22 @@ Then run the interactive setup:
 
 This detects your stack and installs relevant configurations.
 
+## Todo Persistence Across Compaction
+
+**The problem**: Claude Code's context compaction summarizes conversation history to stay
+within token limits. When this happens, your todo list vanishes - you lose track of
+what you were working on.
+
+**The solution**: This plugin automatically saves todos to disk via hooks. After
+compaction, restore them:
+
+```bash
+cat ~/.claude/projects/$(echo $PWD | sed 's|/|-|g')/todos.md
+```
+
+Then use TodoWrite to restore your progress. Your todos survive compaction, session
+restarts, and even `--resume` across days.
+
 ## Example Usage
 
 ```bash
@@ -272,7 +288,8 @@ ai-coding-config/
 │   ├── core/                         # Main plugin
 │   │   ├── commands/                 # 18 workflow commands
 │   │   ├── agents/                   # 24 specialized agents
-│   │   └── skills/                   # 6 autonomous capabilities
+│   │   ├── skills/                   # 6 autonomous capabilities
+│   │   └── hooks/                    # Todo persistence hooks
 │   └── personalities/                # 7 personality variants
 ├── .cursor/rules/                    # 33 coding standards (.mdc)
 ├── docs/                             # Guides

--- a/plugins/core/.claude-plugin/plugin.json
+++ b/plugins/core/.claude-plugin/plugin.json
@@ -9,5 +9,6 @@
   "homepage": "https://github.com/TechNickAI/ai-coding-config",
   "repository": "https://github.com/TechNickAI/ai-coding-config",
   "license": "MIT",
-  "keywords": ["commands", "agents", "skills", "workflows", "essential"]
+  "keywords": ["commands", "agents", "skills", "workflows", "essential"],
+  "hooks": "./hooks/hooks.json"
 }

--- a/plugins/core/.claude-plugin/plugin.json
+++ b/plugins/core/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-coding-config",
-  "version": "9.14.0",
+  "version": "9.15.0",
   "description": "Commands, agents, skills, and context for AI-assisted development workflows",
   "author": {
     "name": "TechNickAI",

--- a/plugins/core/context.md
+++ b/plugins/core/context.md
@@ -15,3 +15,11 @@ co-creative evolution for the whole.
 
 Coding rules are available in `rules/`. Use `/load-rules` to analyze the current task
 and load relevant rules dynamically.
+
+# Todo Persistence
+
+Todos are automatically saved to Claude's project directory via hooks. After context
+compaction, if your todo list appears empty but you were working on tasks:
+
+1. Check for saved todos: `cat ~/.claude/projects/$(echo $PWD | sed 's|/|-|g')/todos.md`
+2. If found, restore them via TodoWrite to continue tracking progress

--- a/plugins/core/hooks/hooks.json
+++ b/plugins/core/hooks/hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "TodoWrite",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/todo-persist.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/core/hooks/todo-persist.sh
+++ b/plugins/core/hooks/todo-persist.sh
@@ -28,7 +28,7 @@ PROJECT_DIR=$(dirname "$TRANSCRIPT_PATH")
 {
     echo "# Saved Todos"
     echo ""
-    echo "Updated: $(date -Iseconds)"
+    echo "Updated: $(date -u +"%Y-%m-%dT%H:%M:%SZ")"
     echo ""
 
     # Group by status

--- a/plugins/core/hooks/todo-persist.sh
+++ b/plugins/core/hooks/todo-persist.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# PostToolUse hook for TodoWrite: Save todos in human-readable format
+# Saves to Claude's existing project directory for restoration after compaction
+
+# Read JSON input from stdin
+INPUT=$(cat)
+
+# Extract fields
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty')
+TRANSCRIPT_PATH=$(echo "$INPUT" | jq -r '.transcript_path // empty')
+
+# Only process TodoWrite calls
+if [ "$TOOL_NAME" != "TodoWrite" ]; then
+    exit 0
+fi
+
+# Extract todos array from tool_input
+TODOS=$(echo "$INPUT" | jq -r '.tool_input.todos // empty')
+
+if [ -z "$TODOS" ] || [ "$TODOS" = "null" ] || [ -z "$TRANSCRIPT_PATH" ]; then
+    exit 0
+fi
+
+# Use Claude's existing project directory (parent of transcript file)
+PROJECT_DIR=$(dirname "$TRANSCRIPT_PATH")
+
+# Convert to readable markdown
+{
+    echo "# Saved Todos"
+    echo ""
+    echo "Updated: $(date -Iseconds)"
+    echo ""
+
+    # Group by status
+    for status in "in_progress" "pending" "completed"; do
+        items=$(echo "$TODOS" | jq -r --arg s "$status" '.[] | select(.status == $s) | .content')
+        if [ -n "$items" ]; then
+            case $status in
+                in_progress) echo "## In Progress" ;;
+                pending) echo "## Pending" ;;
+                completed) echo "## Completed" ;;
+            esac
+            echo ""
+            echo "$items" | while read -r item; do
+                [ -n "$item" ] && echo "- $item"
+            done
+            echo ""
+        fi
+    done
+} > "$PROJECT_DIR/todos.md"
+
+exit 0


### PR DESCRIPTION
## Summary

- Adds PostToolUse hook that saves todos to Claude's project directory as human-readable markdown
- Uses `transcript_path` to store in Claude's existing `~/.claude/projects/{project}/` structure
- Adds restoration instructions to context.md

## Problem

Todos don't survive context compaction. This is a well-known issue ([#14258](https://github.com/anthropics/claude-code/issues/14258)) with no existing solution.

## Solution

A single PostToolUse hook that:
1. Intercepts every `TodoWrite` call
2. Extracts todos from the tool input JSON
3. Saves them as readable markdown to `~/.claude/projects/{project}/todos.md`

After compaction, context.md instructs Claude how to restore:
```bash
cat ~/.claude/projects/$(echo $PWD | sed 's|/|-|g')/todos.md
```

## Design choices

- **Project-scoped, not session-scoped**: Multiple sessions in the same project share todos (simpler, usually correct)
- **Uses existing infrastructure**: Stores in Claude's `~/.claude/projects/` directory rather than inventing new paths
- **Human-readable format**: Markdown grouped by status, not JSON
- **No files in repo**: Everything stored in `~/.claude/`

## Test plan

- [x] Validated hook scripts with `bash -n`
- [x] Tested todo-persist.sh with simulated PostToolUse input
- [x] Verified discovery command works from project directory
- [ ] Test in new Claude Code session (hooks load at startup)
- [ ] Test compaction recovery flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)