### PR TITLE
Add fix-first heuristic to multi-review

### DIFF
--- a/plugins/core/commands/multi-review.md
+++ b/plugins/core/commands/multi-review.md
@@ -2,7 +2,7 @@
 # prettier-ignore
 description: "Multi-agent code review with diverse perspectives - run multiple specialized reviewers in parallel for comprehensive analysis"
 argument-hint: "[count|depth]"
-version: 2.2.0
+version: 3.0.0
 model: inherit
 ---
 
@@ -80,14 +80,52 @@ recent modifications). Analyze what domains the code touches. Select N agents en
 diversity across domains. Launch all agents in parallel using multiple Task tool calls
 in a single message.
 
-After agents complete:
+After agents complete, apply the fix-first synthesis workflow:
 
-1. Synthesize results: deduplicate, group by severity, note which agent caught each
-   issue
-2. For each issue, determine: fix now, wontfix (with reason), or large scope (create
-   task)
-3. Fix all "fix now" issues immediately
-4. Report summary of what was fixed and what was declined (with reasons) </execution>
+1. **Collect**: Gather all findings, deduplicate across agents, group by severity, note
+   which agent caught each issue
+
+2. **Classify** each finding as AUTO-FIX or ASK:
+
+   **AUTO-FIX** — Apply immediately without asking. High confidence, unambiguous, low
+   risk of changing behavior in unexpected ways:
+   - Unused imports, dead code flagged by multiple agents
+   - Missing `await` on async calls
+   - Obvious null/undefined checks where crash is certain
+   - Wrong casing or naming convention violations
+   - Missing error propagation (empty catch blocks, swallowed errors)
+   - Import ordering, formatting issues
+   - Straightforward type fixes (wrong type annotation, missing return type)
+   - Duplicate code that multiple agents independently flagged
+
+   **ASK** — Batch into a single question for the user. Needs judgment, multiple valid
+   approaches, or risk of unintended behavior change:
+   - Architectural restructuring or pattern changes
+   - Performance optimizations with trade-offs
+   - Security-sensitive changes (auth, crypto, input validation)
+   - Changes that alter public API or user-facing behavior
+   - Suggestions where the "right" answer depends on product context
+   - Anything that touches test assertions or expected values
+   - Changes where reasonable engineers would disagree
+
+3. **Fix**: Apply all AUTO-FIX items immediately. Keep a running list of what was fixed.
+
+4. **Ask**: If any ASK items exist, present them in a single batch with context and a
+   recommendation for each. Format:
+
+   ```
+   Review found N items needing your input:
+
+   1. [Agent: security-reviewer] SQL query in user-search.ts:42 uses string
+      interpolation → RECOMMENDATION: parameterize, because user input flows here
+   2. [Agent: architecture-auditor] Service layer bypasses repository pattern
+      → RECOMMENDATION: keep as-is, this is a one-off admin endpoint
+   ```
+
+5. **Apply user decisions**: Fix items the user approves, mark others as wontfix.
+
+6. **Report**: Summary of everything — auto-fixed, user-approved fixes, and declined
+   items with reasons. </execution>
 
 <dynamic-agents>
 When code requires domain expertise no existing agent provides, create a focused
@@ -98,9 +136,13 @@ Common domains: Temporal workflows, GraphQL, database migrations, rate limiting,
 authentication, caching, streaming, real-time updates. </dynamic-agents>
 
 <output-format>
-After fixing issues, provide a summary:
+After completing the fix-first workflow, provide a summary:
 
-**Fixed** (N issues):
+**Auto-fixed** (N issues):
+
+- Issue description → what was changed (agent that caught it)
+
+**User-approved fixes** (N issues, only if ASK items were presented):
 
 - Issue description → what was changed
 
@@ -112,4 +154,6 @@ After fixing issues, provide a summary:
 
 - Issue description → follow-up task created
 
-If all agents return no issues, note this explicitly. </output-format>
+If all agents return no issues, note this explicitly. When called from /ship or
+/autotask, keep the summary concise — the caller will incorporate it into the PR body.
+</output-format>

--- a/plugins/core/commands/multi-review.md
+++ b/plugins/core/commands/multi-review.md
@@ -85,21 +85,23 @@ After agents complete, apply the fix-first synthesis workflow:
 1. **Collect**: Gather all findings, deduplicate across agents, group by severity, note
    which agent caught each issue
 
-2. **Classify** each finding as AUTO-FIX or ASK:
+2. **Classify** each finding as AUTO-FIX, ASK, or DEFER:
 
    **AUTO-FIX** — Apply immediately without asking. High confidence, unambiguous, low
-   risk of changing behavior in unexpected ways:
+   risk of changing behavior in unexpected ways. In test files, only apply AUTO-FIX for
+   import/formatting issues — route logic changes to ASK:
    - Unused imports, dead code flagged by multiple agents
-   - Missing `await` on async calls
+   - Missing `await` where the return value is used or error must be caught (not
+     fire-and-forget patterns — those require judgment and belong in ASK)
    - Obvious null/undefined checks where crash is certain
    - Wrong casing or naming convention violations
    - Missing error propagation (empty catch blocks, swallowed errors)
    - Import ordering, formatting issues
    - Straightforward type fixes (wrong type annotation, missing return type)
-   - Duplicate code that multiple agents independently flagged
 
    **ASK** — Batch into a single question for the user. Needs judgment, multiple valid
-   approaches, or risk of unintended behavior change:
+   approaches, or risk of unintended behavior change. **When in doubt, classify as
+   ASK.**
    - Architectural restructuring or pattern changes
    - Performance optimizations with trade-offs
    - Security-sensitive changes (auth, crypto, input validation)
@@ -107,11 +109,18 @@ After agents complete, apply the fix-first synthesis workflow:
    - Suggestions where the "right" answer depends on product context
    - Anything that touches test assertions or expected values
    - Changes where reasonable engineers would disagree
+   - Missing `await` on fire-and-forget patterns (behavior change, not just style)
+   - Deduplication requiring abstraction design decisions (where does it live?)
+
+   **DEFER** — Valid but out of scope for this PR. Create a follow-up task and note it:
+   - Improvements to shared utilities used across many files
+   - Refactors that touch unrelated code
+   - Suggestions that would significantly expand PR scope
 
 3. **Fix**: Apply all AUTO-FIX items immediately. Keep a running list of what was fixed.
 
 4. **Ask**: If any ASK items exist, present them in a single batch with context and a
-   recommendation for each. Format:
+   recommendation for each. Use the actual agent name that caught the issue:
 
    ```
    Review found N items needing your input:
@@ -124,8 +133,9 @@ After agents complete, apply the fix-first synthesis workflow:
 
 5. **Apply user decisions**: Fix items the user approves, mark others as wontfix.
 
-6. **Report**: Summary of everything — auto-fixed, user-approved fixes, and declined
-   items with reasons. </execution>
+6. **Report**: Summary of everything — auto-fixed, user-approved fixes, declined items
+   with reasons, and deferred items with task references. Omit empty sections.
+   </execution>
 
 <dynamic-agents>
 When code requires domain expertise no existing agent provides, create a focused
@@ -142,7 +152,7 @@ After completing the fix-first workflow, provide a summary:
 
 - Issue description → what was changed (agent that caught it)
 
-**User-approved fixes** (N issues, only if ASK items were presented):
+**User-approved fixes** (N issues, only if ASK items were presented and approved):
 
 - Issue description → what was changed
 


### PR DESCRIPTION
## Summary
- Review findings now auto-classified as **AUTO-FIX** (obvious, unambiguous) or **ASK** (needs judgment)
- Auto-fixes applied immediately without asking; ASK items batched into single question with recommendations
- Inspired by gstack's fix-first review pattern — reduces round-trips and lets /ship flow without unnecessary pauses

## Changes
- `plugins/core/commands/multi-review.md` — v2.2.0 → v3.0.0
  - New 6-step fix-first synthesis workflow (Collect → Classify → Fix → Ask → Apply → Report)
  - Explicit AUTO-FIX criteria (unused imports, missing await, empty catches, etc.)
  - Explicit ASK criteria (architectural, security-sensitive, behavior changes)
  - Updated output format: auto-fixed vs user-approved vs wontfix vs deferred

## Test plan
- [ ] Run `/multi-review` on a branch with known issues — verify AUTO-FIX items are fixed without asking
- [ ] Verify ASK items are batched into single question
- [ ] Run `/multi-review` from `/autotask` — verify concise output

🤖 Generated with [Claude Code](https://claude.com/claude-code)