### PR TITLE
Add session multiplexing detection

### DIFF
--- a/plugins/core/hooks/hooks.json
+++ b/plugins/core/hooks/hooks.json
@@ -1,5 +1,16 @@
 {
   "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|clear|compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/session-multiplexing.sh"
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "TodoWrite",

--- a/plugins/core/hooks/session-multiplexing.sh
+++ b/plugins/core/hooks/session-multiplexing.sh
@@ -17,20 +17,18 @@ fi
 SESSION_DIR="$HOME/.claude/sessions"
 mkdir -p "$SESSION_DIR"
 
-# Touch this session's file
-touch "$SESSION_DIR/$SESSION_ID"
+# Sanitize session_id to prevent path traversal — use only the basename
+SESSION_FILE="$SESSION_DIR/$(basename "$SESSION_ID")"
+touch "$SESSION_FILE"
 
-# Count sessions modified in last 2 hours
-if [[ "$OSTYPE" == "darwin"* ]]; then
-    ACTIVE_COUNT=$(find "$SESSION_DIR" -type f -mmin -120 2>/dev/null | wc -l | tr -d ' ')
-else
-    ACTIVE_COUNT=$(find "$SESSION_DIR" -type f -mmin -120 2>/dev/null | wc -l | tr -d ' ')
-fi
+# Count sessions modified in last 2 hours (find -mmin works on both macOS and Linux)
+ACTIVE_COUNT=$(find "$SESSION_DIR" -type f -mmin -120 2>/dev/null | wc -l | tr -d ' ')
 
 # Clean up sessions older than 24 hours
 find "$SESSION_DIR" -type f -mmin +1440 -delete 2>/dev/null
 
-# When 3+ sessions active, add context re-grounding reminder
+# Threshold: 3+ sessions is where context-juggling becomes error-prone.
+# Below 3, a user can reasonably track what each window is doing.
 if [ "$ACTIVE_COUNT" -ge 3 ]; then
     echo "Multi-session mode: $ACTIVE_COUNT active Claude Code sessions detected. The user is juggling multiple windows — always include explicit context (repo name, branch, what we're working on) when reporting status or completing work."
 fi

--- a/plugins/core/hooks/session-multiplexing.sh
+++ b/plugins/core/hooks/session-multiplexing.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# SessionStart hook: Detect multiple active Claude Code sessions
+# Touches a session file and counts active sessions (modified in last 2 hours)
+# When 3+ active, outputs a reminder to re-ground context in responses
+
+# Read JSON input from stdin
+INPUT=$(cat)
+
+# Extract session_id
+SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty')
+
+if [ -z "$SESSION_ID" ]; then
+    exit 0
+fi
+
+# Session tracking directory
+SESSION_DIR="$HOME/.claude/sessions"
+mkdir -p "$SESSION_DIR"
+
+# Touch this session's file
+touch "$SESSION_DIR/$SESSION_ID"
+
+# Count sessions modified in last 2 hours
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    ACTIVE_COUNT=$(find "$SESSION_DIR" -type f -mmin -120 2>/dev/null | wc -l | tr -d ' ')
+else
+    ACTIVE_COUNT=$(find "$SESSION_DIR" -type f -mmin -120 2>/dev/null | wc -l | tr -d ' ')
+fi
+
+# Clean up sessions older than 24 hours
+find "$SESSION_DIR" -type f -mmin +1440 -delete 2>/dev/null
+
+# When 3+ sessions active, add context re-grounding reminder
+if [ "$ACTIVE_COUNT" -ge 3 ]; then
+    echo "Multi-session mode: $ACTIVE_COUNT active Claude Code sessions detected. The user is juggling multiple windows — always include explicit context (repo name, branch, what we're working on) when reporting status or completing work."
+fi
+
+exit 0


### PR DESCRIPTION
## Summary
- New SessionStart hook that detects when 3+ Claude Code sessions are active simultaneously
- Outputs context re-grounding reminder so responses include explicit repo/branch/task info
- Designed for multi-window workflows where context switching is constant

## Changes
- `plugins/core/hooks/session-multiplexing.sh` — new hook script
  - Touches `~/.claude/sessions/{SESSION_ID}` on every session start/resume/clear/compact
  - Counts files modified in last 2 hours
  - At 3+ active: injects multi-session reminder
  - Auto-cleans session files older than 24 hours
- `plugins/core/hooks/hooks.json` — added SessionStart hook entry

## Test plan
- [ ] Start 3+ Claude Code sessions — verify "Multi-session mode" message appears
- [ ] Verify session files created in `~/.claude/sessions/`
- [ ] Verify old session files cleaned up after 24h
- [ ] Verify single-session usage produces no extra output

🤖 Generated with [Claude Code](https://claude.com/claude-code)