### PR TITLE
Enhance /handoff-context with save-session structural patterns

### DIFF
--- a/plugins/core/commands/handoff-context.md
+++ b/plugins/core/commands/handoff-context.md
@@ -1,7 +1,7 @@
 ---
 # prettier-ignore
 description: "Generate context handoff and copy to clipboard for new session - preserves decisions, progress, and next steps across conversations"
-version: 1.0.1
+version: 1.1.0
 ---
 
 # Handoff Context
@@ -20,31 +20,85 @@ Do not ask for permission - execute immediately. </execution>
 # Context Handoff
 
 <context_handoff> <original_task> [State the original, specific request or task]
-</original_task> <work_completed> [List everything successfully accomplished with file
-paths and line numbers] </work_completed> <work_remaining> [Detail work that still needs
-to be done with priorities] </work_remaining> <attempted_approaches> [Document
-approaches that didn't work and why] </attempted_approaches> <critical_context>
-[Preserve essential technical, project, and business context] </critical_context>
-<current_state> [Describe exact state of deliverables and system] </current_state>
-<recommendations> [Provide actionable next steps in priority order] </recommendations>
-</context_handoff>
+</original_task>
 
+<decisions_made> [Architecture choices, tradeoffs accepted, approaches chosen — with the
+reason each was picked over alternatives. Prevents the next session from relitigating
+settled calls.]
+
+- [decision] — reason: [why this over alternatives] </decisions_made>
+
+<work_completed> [Every item here MUST include evidence. "Confirmed by: test passed /
+curl returned 200 / visible in Supabase / Postman response attached." Without evidence,
+move the item to untried_approaches.]
+
+- [thing that works] — confirmed by: [specific evidence] </work_completed>
+
+<files>
+[Every file touched. Table format for scannability.]
+| File              | Status        | Notes                      |
+| ----------------- | ------------- | -------------------------- |
+| `path/to/file.ts` | Complete      | [what it does]             |
+| `path/to/file.ts` | In Progress   | [what's done, what's left] |
+| `path/to/file.ts` | Broken        | [what's wrong]             |
+| `path/to/file.ts` | Not Started   | [planned but not touched]  |
+</files>
+
+<work_remaining> [Work that still needs to be done, in priority order. Distinct from
+blockers (these are doable now).] </work_remaining>
+
+<failed_approaches> [Approaches tried that did NOT work. Pair each with the EXACT
+failure reason so the next session does not retry blindly. "Threw X error because Y" is
+useful; "didn't work" is not.]
+
+- [approach tried] — failed because: [exact reason / error message] </failed_approaches>
+
+<untried_approaches> [Promising ideas that have NOT yet been attempted. Distinct from
+failed — these are still open. Be specific enough that the next session knows exactly
+what to try.]
+
+- [approach / idea] </untried_approaches>
+
+<blockers>
+[Unresolved external dependencies, open questions waiting on answers, things blocked on someone/something outside the session. Distinct from work_remaining (those are doable; these aren't yet).]
+</blockers>
+
+<critical_context> [Essential technical, project, and business context the next session
+needs but can't derive from the code. Git branch, env state, related PR numbers,
+stakeholder constraints, time-sensitive notes.] </critical_context>
+
+<exact_next_step> [The ONE most important action to take on resume. Precise enough that
+starting requires zero thinking. Singular and concrete, e.g., "In
+app/api/auth/login/route.ts line 42, set the JWT as httpOnly cookie via
+cookies().set(...), then curl the endpoint to verify Set-Cookie header is present."]
+</exact_next_step>
+
+<recommendations>
+[Actionable next steps in priority order, as a backup to exact_next_step.]
+</recommendations>
+</context_handoff>
 ```
 </handoff-format>
+
+<honesty-requirement>
+Write "N/A" or "None" in sections that genuinely have no content — incomplete is worse than honest empty. Skipping a section is indistinguishable from forgetting to fill it, which leaves the next session guessing. An empty `<blockers>None</blockers>` is a positive signal; a missing `<blockers>` tag is ambiguous.
+
+If `work_completed` has no evidence-backed items yet, write "Nothing confirmed working
+yet — all approaches still in progress or untested." </honesty-requirement>
 
 <implementation>
 Get timestamp with `date +%s`, use Write tool to save to `/tmp/context_handoff_[timestamp].md`, run `pbcopy < /tmp/context_handoff_[timestamp].md`, show confirmation.
 
-Why Write tool: Avoids git hooks, no escaping issues, faster execution, prevents collisions.
-</implementation>
+Why Write tool: Avoids git hooks, no escaping issues, faster execution, prevents
+collisions. </implementation>
 
 <quality-guidelines>
 For clean copy/paste: Start with `# Context Handoff`, end with `</context_handoff>`, no preambles or summaries.
 
-For comprehensive documentation: Include file paths with line numbers, document all work including minor changes, include failed attempts, preserve error messages and stack traces, note time-sensitive information, include git status and branch info.
-</quality-guidelines>
+For comprehensive documentation: Include file paths with line numbers, document all work
+including minor changes, preserve error messages and stack traces verbatim, note
+time-sensitive information, include git status and branch info. </quality-guidelines>
 
 <success-criteria>
-Handoff should be immediately pasteable into new Claude conversation. New Claude instance should be able to continue work without additional context.
+Handoff should be immediately pasteable into new Claude conversation. New Claude instance should be able to continue work without additional context — and should know which approaches to avoid retrying, which decisions are settled, and the single next step to take.
 </success-criteria>
-```

--- a/plugins/core/commands/handoff-context.md
+++ b/plugins/core/commands/handoff-context.md
@@ -7,20 +7,23 @@ version: 1.1.0
 # Handoff Context
 
 <objective>
-Generate a comprehensive context handoff for the current conversation that can be copied and pasted to continue work in a new session.
+Generate a comprehensive context handoff for the current conversation that can be copied
+and pasted to continue work in a new session.
 </objective>
 
 <execution>
-Create handoff following the XML-structured format, save to timestamped temp file, copy to clipboard automatically. Show brief confirmation: `📋 Copied to clipboard`
+Create handoff following the XML-structured format, save to timestamped temp file, copy
+to clipboard automatically. Show brief confirmation: `📋 Copied to clipboard`
 
 Do not ask for permission - execute immediately. </execution>
 
 <handoff-format>
-```markdown
+```
 # Context Handoff
 
-<context_handoff> <original_task> [State the original, specific request or task]
-</original_task>
+<context_handoff>
+
+<original_task> [State the original, specific request or task] </original_task>
 
 <decisions_made> [Architecture choices, tradeoffs accepted, approaches chosen — with the
 reason each was picked over alternatives. Prevents the next session from relitigating
@@ -30,7 +33,8 @@ settled calls.]
 
 <work_completed> [Every item here MUST include evidence. "Confirmed by: test passed /
 curl returned 200 / visible in Supabase / Postman response attached." Without evidence,
-move the item to untried_approaches.]
+move the item to work_remaining as "Attempted, unconfirmed: [what was tried and why
+verification was unclear]."]
 
 - [thing that works] — confirmed by: [specific evidence] </work_completed>
 
@@ -45,7 +49,8 @@ move the item to untried_approaches.]
 </files>
 
 <work_remaining> [Work that still needs to be done, in priority order. Distinct from
-blockers (these are doable now).] </work_remaining>
+blockers (these are doable now). Include "Attempted, unconfirmed: [description]" for
+work that was tried but whose completion couldn't be verified.] </work_remaining>
 
 <failed_approaches> [Approaches tried that did NOT work. Pair each with the EXACT
 failure reason so the next session does not retry blindly. "Threw X error because Y" is
@@ -60,12 +65,17 @@ what to try.]
 - [approach / idea] </untried_approaches>
 
 <blockers>
-[Unresolved external dependencies, open questions waiting on answers, things blocked on someone/something outside the session. Distinct from work_remaining (those are doable; these aren't yet).]
-</blockers>
+[Unresolved external dependencies, open questions waiting on answers, things blocked on
+someone/something outside the session. Distinct from work_remaining (those are doable;
+these aren't yet).]
+
+- [blocker] — waiting on: [who/what] — unblocked when: [condition] </blockers>
 
 <critical_context> [Essential technical, project, and business context the next session
 needs but can't derive from the code. Git branch, env state, related PR numbers,
-stakeholder constraints, time-sensitive notes.] </critical_context>
+stakeholder constraints, time-sensitive notes. Also include overall system state:
+services running or broken, migrations applied, feature flags set, env vars required.]
+</critical_context>
 
 <exact_next_step> [The ONE most important action to take on resume. Precise enough that
 starting requires zero thinking. Singular and concrete, e.g., "In
@@ -76,29 +86,44 @@ cookies().set(...), then curl the endpoint to verify Set-Cookie header is presen
 <recommendations>
 [Actionable next steps in priority order, as a backup to exact_next_step.]
 </recommendations>
+
 </context_handoff>
+
 ```
 </handoff-format>
 
 <honesty-requirement>
-Write "N/A" or "None" in sections that genuinely have no content — incomplete is worse than honest empty. Skipping a section is indistinguishable from forgetting to fill it, which leaves the next session guessing. An empty `<blockers>None</blockers>` is a positive signal; a missing `<blockers>` tag is ambiguous.
+Write "N/A" or "None" in sections that genuinely have no content — incomplete is worse
+than honest empty. Skipping a section is indistinguishable from forgetting to fill it,
+which leaves the next session guessing. An empty `<blockers>None</blockers>` is a
+positive signal; a missing `<blockers>` tag is ambiguous.
 
 If `work_completed` has no evidence-backed items yet, write "Nothing confirmed working
-yet — all approaches still in progress or untested." </honesty-requirement>
+yet — all approaches still in progress or untested."
+</honesty-requirement>
 
 <implementation>
-Get timestamp with `date +%s`, use Write tool to save to `/tmp/context_handoff_[timestamp].md`, run `pbcopy < /tmp/context_handoff_[timestamp].md`, show confirmation.
+Get timestamp with `date +%s`, use Write tool to save to
+`/tmp/context_handoff_[timestamp].md`, run
+`pbcopy < /tmp/context_handoff_[timestamp].md`, show confirmation.
 
 Why Write tool: Avoids git hooks, no escaping issues, faster execution, prevents
-collisions. </implementation>
+collisions.
+</implementation>
 
 <quality-guidelines>
-For clean copy/paste: Start with `# Context Handoff`, end with `</context_handoff>`, no preambles or summaries.
+For clean copy/paste: Start with `# Context Handoff`, end with `</context_handoff>`, no
+preambles or summaries.
 
 For comprehensive documentation: Include file paths with line numbers, document all work
 including minor changes, preserve error messages and stack traces verbatim, note
-time-sensitive information, include git status and branch info. </quality-guidelines>
+time-sensitive information, include git status and branch info.
+</quality-guidelines>
 
 <success-criteria>
-Handoff should be immediately pasteable into new Claude conversation. New Claude instance should be able to continue work without additional context — and should know which approaches to avoid retrying, which decisions are settled, and the single next step to take.
+Handoff should be immediately pasteable into new Claude conversation. New Claude instance
+should be able to continue work without additional context — and should know which
+approaches to avoid retrying, which decisions are settled, and the single next step to
+take.
 </success-criteria>
+```


### PR DESCRIPTION
## Summary

- Pulls 7 structural improvements from `affaan-m/everything-claude-code`'s `save-session` command into our `/handoff-context` — same ephemeral clipboard purpose, richer captured content.
- Forces the LLM to be honest about *kinds* of information: what's confirmed vs hand-waved, what failed vs untried, what's decided vs open.
- Bumps `plugins/core/commands/handoff-context.md` from v1.0.1 → v1.1.0.

## What changed

| Addition | Why |
|---|---|
| Evidence requirement on `work_completed` | Each item must pair with "confirmed by: [test passed / curl 200 / etc.]". Prevents wishful "done" claims. |
| Split `failed_approaches` + `untried_approaches` | Mixed into one blob previously. Different signals: don't-retry vs. maybe-try-next. |
| `decisions_made` (new) | Settled architecture calls get their own section so next session doesn't relitigate. |
| `blockers` (new) | Distinct from `work_remaining` — those are doable, these aren't yet. |
| `files` table | Scannable `\| File \| Status \| Notes \|` instead of prose, with Complete / In Progress / Broken / Not Started. |
| `exact_next_step` (new) | ONE concrete action on resume, precise enough for zero-think restart. Complements priority-ordered recommendations. |
| `honesty-requirement` section | "Write 'N/A' rather than skip" — a missing tag is indistinguishable from a forgotten section. |

## What intentionally did NOT change

- Still silent/no-prompt ("execute immediately")
- Still writes to `/tmp/context_handoff_[timestamp].md`
- Still copies to clipboard with `pbcopy`
- Still XML-tagged for LLM parsing

## Test plan

- [ ] Run `/handoff-context` on an in-progress session, paste into a fresh session, verify the new Claude instance can continue without additional context
- [ ] Verify `exact_next_step` precision — resuming should require zero thinking
- [ ] Confirm empty sections get filled with "N/A" rather than omitted
- [ ] Confirm clipboard copy still works on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)