### PR TITLE
✨ Add /ai-coding-config doctor diagnostic subcommand

### DIFF
--- a/plugins/core/commands/ai-coding-config.md
+++ b/plugins/core/commands/ai-coding-config.md
@@ -1,8 +1,8 @@
 ---
 # prettier-ignore
 description: "Set up or update AI coding configurations - interactive setup for Claude Code, Cursor, and other AI coding tools"
-argument-hint: "[update]"
-version: 4.1.1
+argument-hint: "[update|doctor]"
+version: 4.2.0
 ---
 
 # AI Coding Configuration
@@ -14,6 +14,7 @@ tools. The marketplace lives at `https://github.com/TechNickAI/ai-coding-config`
 
 - `/ai-coding-config` - Interactive setup for current project
 - `/ai-coding-config update` - Update plugins and configs to latest versions
+- `/ai-coding-config doctor` - Diagnose plugin health, hook state, and config drift
 
 ## Interaction Guidelines
 
@@ -521,6 +522,185 @@ If nothing changed (already up to date, no reset needed), skip the restart messa
 </restart-guidance>
 
 </update-mode>
+
+---
+
+<doctor-mode>
+
+<objective>
+Run a diagnostic battery and report as a ✅ / ⚠️ / ❌ checklist. Group by category.
+End with a suggested-fixes section. Read-only except for hook permission repair (safe,
+reversible, no content change). Work conversationally — print results as you go rather
+than collecting everything silently before reporting.
+</objective>
+
+<context-detection>
+Determine environment before running checks:
+
+- **Source repo**: `plugins/core/` directory exists at cwd. Run all checks including
+  symlink and plugin JSON consistency checks.
+- **User project**: `plugins/core/` absent. Skip source-repo checks; focus on plugin
+  install state, settings, and hooks.
+
+Report which context was detected at the top of output.
+</context-detection>
+
+<checks>
+
+### Plugin Install State
+
+Read `~/.claude/plugins/known_marketplaces.json` with the Read tool:
+- ✅ ai-coding-config marketplace entry present
+- ❌ Not found → suggest `/plugin marketplace add https://github.com/TechNickAI/ai-coding-config`
+
+Check `~/.claude/plugins/cache/ai-coding-config/` for plugin content using Glob:
+- ✅ Cache directory exists with agents, commands, and skills subdirectories
+- ❌ Cache missing or empty → suggest `/plugin install ai-coding-config`
+
+Read `~/.claude/settings.json` and check for plugin enablement:
+- ✅ ai-coding-config appears in plugins/enabled list
+- ⚠️ Not listed → plugin may be disabled; run `/plugin` to check status
+
+### Symlinks (source repo only)
+
+For each directory: `.claude/commands`, `.claude/agents`, `.claude/skills`:
+
+```bash
+ls -la .claude/commands .claude/agents .claude/skills
+```
+
+- ✅ Each is a symlink pointing to the corresponding `plugins/core/` subdirectory
+- ❌ Missing, not a symlink, or wrong target → note the broken symlink
+
+Check `rules/` → `.cursor/rules/`:
+
+```bash
+ls -la rules
+```
+
+- ✅ `rules` is a symlink to `.cursor/rules`
+- ❌ Missing or wrong → `ln -s .cursor/rules rules`
+
+### Hook Scripts
+
+Read `plugins/core/hooks/hooks.json` to get declared hooks. For each hook script:
+
+```bash
+ls -la plugins/core/hooks/*.sh
+```
+
+- ✅ File exists, executable (`-x`), and first line is `#!/bin/bash`
+- ⚠️ Exists but not executable → offer to auto-fix: `chmod +x <path>`
+- ❌ File missing → note as broken
+
+Check that hooks are registered in project or global settings:
+
+```bash
+cat .claude/settings.json 2>/dev/null | python3 -m json.tool > /dev/null && echo "valid"
+```
+
+- ✅ `settings.json` parses as valid JSON
+- ❌ Invalid JSON → note the file and line (use `python3 -m json.tool` output)
+
+### Marketplace JSON Consistency (source repo only)
+
+Read both `.claude-plugin/marketplace.json` and `plugins/core/.claude-plugin/plugin.json`:
+- ✅ Both parse as valid JSON
+- ✅ `metadata.version` == `plugins[0].version` == `plugin.json version`
+- ⚠️ Version mismatch → "Bump all three per `.claude-plugin/CLAUDE.md`"
+
+### Version Drift
+
+Compare installed command version vs source repo version. Read the `version` field from
+the YAML frontmatter of:
+
+1. This command file (currently executing)
+2. `~/.ai_coding_config/plugins/core/commands/ai-coding-config.md` (source, if it exists)
+
+- ✅ Versions match
+- ⚠️ Source is newer → suggest `/ai-coding-config update`
+- ⚠️ Source repo not found at `~/.ai_coding_config` → suggest cloning it
+
+### Skill Frontmatter
+
+Use Glob to list `plugins/core/skills/*/SKILL.md` (source repo) or
+`~/.claude/plugins/cache/ai-coding-config/skills/*/SKILL.md` (user project).
+
+For each SKILL.md, read and verify:
+- ✅ File has `---` YAML frontmatter block
+- ✅ `name`, `description`, and `triggers` fields present
+- ⚠️ Missing `triggers` → skill won't auto-activate on natural language
+- If `next-skill` declared: ✅ that skill name exists in the skills directory or
+  `.claude/commands/` → ⚠️ if target not found
+
+Report a single summary line per skill (not per field) to keep output scannable.
+
+</checks>
+
+<auto-fix>
+Hook permissions are the only thing doctor auto-fixes (with user confirmation):
+
+"⚠️ verify-deliverables.sh is not executable. Fix now? [y/N]"
+
+If yes: `chmod +x plugins/core/hooks/verify-deliverables.sh`
+
+For all other issues, report and direct to the appropriate fix command. Don't modify
+JSON files, settings, or symlinks without explicit user instruction.
+</auto-fix>
+
+<output-format>
+Print category headers as the checks complete. Example final output:
+
+```
+## ai-coding-config doctor
+
+Context: source repo (plugins/core/ detected)
+
+### Plugin Install State
+✅ Marketplace registered (ai-coding-config v9.21.0)
+✅ Plugin cache present
+✅ Plugin enabled in settings
+
+### Symlinks
+✅ .claude/commands → plugins/core/commands
+✅ .claude/agents → plugins/core/agents
+✅ .claude/skills → plugins/core/skills
+❌ rules/ symlink missing
+
+### Hook Scripts
+✅ verify-deliverables.sh — executable, valid shebang
+⚠️ todo-persist.sh — exists but not executable
+
+### Marketplace JSON Consistency
+✅ .claude-plugin/marketplace.json valid JSON
+✅ plugins/core/.claude-plugin/plugin.json valid JSON
+✅ Versions consistent (9.21.0)
+
+### Version Drift
+✅ Command file up to date (v4.2.0)
+
+### Skill Frontmatter
+✅ brainstorming — name, description, triggers, next-skill: brainstorm-synthesis (found)
+✅ systematic-debugging — name, description, triggers, next-skill: verify-fix (found)
+⚠️ mcp-debug — triggers field present, stability: experimental
+
+---
+## Summary
+11 passed ✅  1 warning ⚠️  1 failure ❌
+
+## Suggested Fixes
+❌ rules/ symlink missing:
+   ln -s .cursor/rules rules
+
+⚠️ todo-persist.sh not executable:
+   chmod +x plugins/core/hooks/todo-persist.sh
+   (or confirm above to auto-fix)
+```
+
+Keep the summary tight. Users should be able to skim it in 10 seconds.
+</output-format>
+
+</doctor-mode>
 
 ---
 

--- a/plugins/core/commands/ai-coding-config.md
+++ b/plugins/core/commands/ai-coding-config.md
@@ -530,8 +530,8 @@ If nothing changed (already up to date, no reset needed), skip the restart messa
 <objective>
 Run a diagnostic battery and report as a ✅ / ⚠️ / ❌ checklist. Group by category.
 End with a suggested-fixes section. Read-only except for hook permission repair (safe,
-reversible, no content change). Work conversationally — print results as you go rather
-than collecting everything silently before reporting.
+reversible, no content change). Print each category header as you complete that group of
+checks so the user sees progress — don't collect everything silently before reporting.
 </objective>
 
 <context-detection>
@@ -596,11 +596,11 @@ ls -la plugins/core/hooks/*.sh
 Check that hooks are registered in project or global settings:
 
 ```bash
-cat .claude/settings.json 2>/dev/null | python3 -m json.tool > /dev/null && echo "valid"
+jq . .claude/settings.json > /dev/null 2>&1 && echo "valid" || echo "invalid"
 ```
 
 - ✅ `settings.json` parses as valid JSON
-- ❌ Invalid JSON → note the file and line (use `python3 -m json.tool` output)
+- ❌ Invalid JSON → note the parse error from jq output
 
 ### Marketplace JSON Consistency (source repo only)
 
@@ -619,12 +619,13 @@ the YAML frontmatter of:
 
 - ✅ Versions match
 - ⚠️ Source is newer → suggest `/ai-coding-config update`
-- ⚠️ Source repo not found at `~/.ai_coding_config` → suggest cloning it
+- ℹ️ Source repo not found at `~/.ai_coding_config` — normal for plugin-only users (no action needed)
 
 ### Skill Frontmatter
 
-Use Glob to list `plugins/core/skills/*/SKILL.md` (source repo) or
-`~/.claude/plugins/cache/ai-coding-config/skills/*/SKILL.md` (user project).
+Use Glob to list `plugins/core/skills/*/SKILL.md` (source repo only — the plugin cache
+uses flat `.md` files without subdirectories, so this check applies only in the source
+repo context).
 
 For each SKILL.md, read and verify:
 - ✅ File has `---` YAML frontmatter block
@@ -686,7 +687,7 @@ Context: source repo (plugins/core/ detected)
 
 ---
 ## Summary
-11 passed ✅  1 warning ⚠️  1 failure ❌
+1 failure ❌  2 warnings ⚠️  11 passed ✅
 
 ## Suggested Fixes
 ❌ rules/ symlink missing:
@@ -696,6 +697,8 @@ Context: source repo (plugins/core/ detected)
    chmod +x plugins/core/hooks/todo-persist.sh
    (or confirm above to auto-fix)
 ```
+
+All-green output ends with: "All checks passed — your setup is healthy."
 
 Keep the summary tight. Users should be able to skim it in 10 seconds.
 </output-format>

--- a/plugins/core/commands/ai-coding-config.md
+++ b/plugins/core/commands/ai-coding-config.md
@@ -565,8 +565,10 @@ Read `~/.claude/settings.json` and check for plugin enablement:
 
 For each directory: `.claude/commands`, `.claude/agents`, `.claude/skills`:
 
+Use Bash with absolute paths anchored to `$(pwd)`:
+
 ```bash
-ls -la .claude/commands .claude/agents .claude/skills
+ls -la "$(pwd)/.claude/commands" "$(pwd)/.claude/agents" "$(pwd)/.claude/skills"
 ```
 
 - ✅ Each is a symlink pointing to the corresponding `plugins/core/` subdirectory
@@ -575,7 +577,7 @@ ls -la .claude/commands .claude/agents .claude/skills
 Check `rules/` → `.cursor/rules/`:
 
 ```bash
-ls -la rules
+ls -la "$(pwd)/rules"
 ```
 
 - ✅ `rules` is a symlink to `.cursor/rules`
@@ -583,11 +585,8 @@ ls -la rules
 
 ### Hook Scripts
 
-Read `plugins/core/hooks/hooks.json` to get declared hooks. For each hook script:
-
-```bash
-ls -la plugins/core/hooks/*.sh
-```
+Read `plugins/core/hooks/hooks.json` with the Read tool to get declared hooks. Use Glob
+to list `plugins/core/hooks/*.sh`, then check each file individually:
 
 - ✅ File exists, executable (`-x`), and first line is `#!/bin/bash`
 - ⚠️ Exists but not executable → offer to auto-fix: `chmod +x <path>`
@@ -631,8 +630,10 @@ For each SKILL.md, read and verify:
 - ✅ File has `---` YAML frontmatter block
 - ✅ `name`, `description`, and `triggers` fields present
 - ⚠️ Missing `triggers` → skill won't auto-activate on natural language
-- If `next-skill` declared: ✅ that skill name exists in the skills directory or
-  `.claude/commands/` → ⚠️ if target not found
+- If `next-skill` declared: check by directory name first (fast path — the directory
+  name should match the skill name); if not found, fall back to scanning `name` fields
+  in each SKILL.md. Also check `.claude/commands/` for commands. ✅ target found,
+  ⚠️ target not found anywhere
 
 Report a single summary line per skill (not per field) to keep output scannable.
 
@@ -641,9 +642,9 @@ Report a single summary line per skill (not per field) to keep output scannable.
 <auto-fix>
 Hook permissions are the only thing doctor auto-fixes (with user confirmation):
 
-"⚠️ verify-deliverables.sh is not executable. Fix now? [y/N]"
+"⚠️ todo-persist.sh is not executable. Fix now? [y/N]"
 
-If yes: `chmod +x plugins/core/hooks/verify-deliverables.sh`
+If yes: `chmod +x plugins/core/hooks/todo-persist.sh`
 
 For all other issues, report and direct to the appropriate fix command. Don't modify
 JSON files, settings, or symlinks without explicit user instruction.

--- a/plugins/core/commands/ai-coding-config.md
+++ b/plugins/core/commands/ai-coding-config.md
@@ -585,21 +585,23 @@ ls -la "$(pwd)/rules"
 
 ### Hook Scripts
 
-Read `plugins/core/hooks/hooks.json` with the Read tool to get declared hooks. Use Glob
-to list `plugins/core/hooks/*.sh`, then check each file individually:
+**Source repo:** Read `plugins/core/hooks/hooks.json` with the Read tool to get
+declared hooks. Use Glob to list `plugins/core/hooks/*.sh`, then check each file:
 
 - ✅ File exists, executable (`-x`), and first line is `#!/bin/bash`
 - ⚠️ Exists but not executable → offer to auto-fix: `chmod +x <path>`
 - ❌ File missing → note as broken
 
-Check that hooks are registered in project or global settings:
+**User project:** Hook script files are managed by the plugin cache — skip the script
+file checks. Instead, verify hooks are registered in settings (see below).
 
-```bash
-jq . .claude/settings.json > /dev/null 2>&1 && echo "valid" || echo "invalid"
-```
+Check that hooks are registered in project or global settings. Read `.claude/settings.json`
+if it exists; otherwise fall back to `~/.claude/settings.json`:
 
-- ✅ `settings.json` parses as valid JSON
-- ❌ Invalid JSON → note the parse error from jq output
+- ✅ Settings file parses as valid JSON and contains hook entries
+- ⚠️ Valid JSON but no hooks registered → hooks won't fire; suggest running `/ai-coding-config update`
+- ❌ Invalid JSON → note the parse error
+- ℹ️ No local `.claude/settings.json` and global settings has no hooks → hooks rely on plugin marketplace loading
 
 ### Marketplace JSON Consistency (source repo only)
 
@@ -640,7 +642,8 @@ Report a single summary line per skill (not per field) to keep output scannable.
 </checks>
 
 <auto-fix>
-Hook permissions are the only thing doctor auto-fixes (with user confirmation):
+Hook permissions are the only thing doctor auto-fixes (with user confirmation), and
+only in source-repo context where the script files are present:
 
 "⚠️ todo-persist.sh is not executable. Fix now? [y/N]"
 

--- a/plugins/core/commands/ai-coding-config.md
+++ b/plugins/core/commands/ai-coding-config.md
@@ -16,6 +16,14 @@ tools. The marketplace lives at `https://github.com/TechNickAI/ai-coding-config`
 - `/ai-coding-config update` - Update plugins and configs to latest versions
 - `/ai-coding-config doctor` - Diagnose plugin health, hook state, and config drift
 
+## Mode Routing
+
+- No argument → setup mode
+- `update` → update mode
+- `doctor` → doctor mode
+- Unrecognized argument (typo, unknown subcommand) → setup mode; mention available
+  subcommands (`update`, `doctor`) at the start of output
+
 ## Interaction Guidelines
 
 Use AskUserQuestion when presenting discrete choices that save the user time (selecting
@@ -549,9 +557,13 @@ Report which context was detected at the top of output.
 
 ### Plugin Install State
 
+These checks mirror the ones in `<marketplace-doctor>` (update-mode). If either section
+is updated (e.g., a new settings key), keep both in sync.
+
 Read `~/.claude/plugins/known_marketplaces.json` with the Read tool:
 - ✅ ai-coding-config marketplace entry present
-- ❌ Not found → suggest `/plugin marketplace add https://github.com/TechNickAI/ai-coding-config`
+- ❌ File not found → marketplace never initialized; suggest `/plugin marketplace add https://github.com/TechNickAI/ai-coding-config`
+- ❌ File exists but ai-coding-config entry missing → suggest `/plugin marketplace add https://github.com/TechNickAI/ai-coding-config`
 
 Check `~/.claude/plugins/cache/ai-coding-config/` for plugin content using Glob:
 - ✅ Cache directory exists with agents, commands, and skills subdirectories
@@ -636,6 +648,8 @@ For each SKILL.md, read and verify:
   name should match the skill name); if not found, fall back to scanning `name` fields
   in each SKILL.md. Also check `.claude/commands/` for commands. ✅ target found,
   ⚠️ target not found anywhere
+- If `stability: experimental` declared: ℹ️ note as informational (expected for new or
+  actively-changing skills — not a problem, just surfaced for awareness)
 
 Report a single summary line per skill (not per field) to keep output scannable.
 


### PR DESCRIPTION
## Summary

- Adds a `doctor` subcommand to `/ai-coding-config` via a new `<doctor-mode>` section in the command file
- Runs a ✅/⚠️/❌ diagnostic battery grouped by category: plugin install state, symlinks, hook scripts, settings JSON, marketplace JSON consistency, version drift, skill frontmatter
- Context-aware: detects source-repo vs user-project and runs applicable checks
- Auto-fixes hook permissions (with confirmation); all other issues report with suggested fix commands

## Design Decisions

**Extension vs new command:** Added as a subcommand to the existing `/ai-coding-config` command rather than creating a standalone file. Users invoke it as `/ai-coding-config doctor`, matching the familiar pattern from `/ai-coding-config update`. The XML mode section pattern already established in the command handles routing cleanly.

**Read-only by default:** Doctor only auto-fixes hook permissions (safe, reversible, no content change). Everything else gets a diagnosis and a fix suggestion — the user runs the fix explicitly. This prevents doctor from accidentally doing destructive things in a broken state.

**Context-aware checks:** Source-repo checks (symlinks, marketplace JSON parity) are skipped in user-project context where they'd always fail. User-project checks (plugin cache, settings enablement) are emphasized instead.

**Skill frontmatter validation includes composition fields:** Since #52 landed, doctor also verifies `next-skill` targets resolve — first live consumer of the new frontmatter schema.

## Complexity

balanced

## Validation

- Pre-commit markdown frontmatter validation passed
- Manually verified the doctor mode section is syntactically valid and follows existing command patterns

Fixes #53