### PR TITLE
fix(doctor): correct ℹ️ icon and generalize hook example from PR #56 review

### DIFF
--- a/plugins/core/commands/ai-coding-config.md
+++ b/plugins/core/commands/ai-coding-config.md
@@ -659,9 +659,9 @@ Report a single summary line per skill (not per field) to keep output scannable.
 Hook permissions are the only thing doctor auto-fixes (with user confirmation), and
 only in source-repo context where the script files are present:
 
-"⚠️ todo-persist.sh is not executable. Fix now? [y/N]"
+"⚠️ <hook-name>.sh is not executable. Fix now? [y/N]"
 
-If yes: `chmod +x plugins/core/hooks/todo-persist.sh`
+If yes: `chmod +x plugins/core/hooks/<hook-name>.sh`
 
 For all other issues, report and direct to the appropriate fix command. Don't modify
 JSON files, settings, or symlinks without explicit user instruction.
@@ -701,7 +701,7 @@ Context: source repo (plugins/core/ detected)
 ### Skill Frontmatter
 ✅ brainstorming — name, description, triggers, next-skill: brainstorm-synthesis (found)
 ✅ systematic-debugging — name, description, triggers, next-skill: verify-fix (found)
-⚠️ mcp-debug — triggers field present, stability: experimental
+ℹ️ mcp-debug — triggers field present, stability: experimental
 
 ---
 ## Summary


### PR DESCRIPTION
## Summary

Follow-up fixes from bot review feedback on #56 (ai-coding-config doctor subcommand).

## Changes

### Bug Fix: Icon inconsistency (⚠️ → ℹ️ for experimental stability)
Both `cursor[bot]` and `claude[bot]` caught that the example output used `⚠️` for
`stability: experimental` while the spec explicitly says `ℹ️` (informational, not a
warning). This was the only issue that could cause incorrect LLM output at runtime.

**Before:** `⚠️ mcp-debug — triggers field present, stability: experimental`  
**After:** `ℹ️ mcp-debug — triggers field present, stability: experimental`

### Improvement: Generalize hardcoded hook filename in auto-fix example
`claude[bot]` noted that hardcoding `todo-persist.sh` in the auto-fix example could
cause LLMs to pattern-match and substitute the literal filename instead of the actual
failing hook. Generalized to `<hook-name>.sh` placeholder.

## Declined feedback

- **Design smell: duplicated logic with `<marketplace-doctor>`** — valid observation, tracked in a separate issue (see below), but refactoring is out of scope for this sweep.
- **Plugin enablement warning underspecific** — the correct subcommand is context-dependent; adding a potentially-wrong specific command could be worse than the current generic guidance.
- **No agent frontmatter check** — valid gap, explicitly calling out as out of scope via GitHub issue.

Closes feedback from: cursor[bot] comment on PR #56, claude[bot] review on PR #56